### PR TITLE
Network data gauge

### DIFF
--- a/services/api/src/api_key.py
+++ b/services/api/src/api_key.py
@@ -52,11 +52,8 @@ api_key_header = APIKeyHeader(name="ndif-api-key", auto_error=False)
 def extract_request_metadata(raw_request: Request):
     content_length = raw_request.headers.get('content-length')
     
-    # Handle IP address, including proxy headers
+    # Handle IP address
     ip_address = raw_request.client.host
-    forwarded_for = raw_request.headers.get('x-forwarded-for')
-    if forwarded_for:
-        ip_address = forwarded_for.split(',')[0]  # Take the first IP in the list
 
     # Extract User-Agent
     user_agent = raw_request.headers.get('user-agent')

--- a/services/api/src/api_key.py
+++ b/services/api/src/api_key.py
@@ -4,7 +4,7 @@ import firebase_admin
 from bson.objectid import ObjectId
 from cachetools import TTLCache, cached
 from datetime import datetime
-from fastapi import HTTPException, Security
+from fastapi import HTTPException, Request, Security
 from fastapi.security.api_key import APIKeyHeader
 from firebase_admin import credentials, firestore
 from starlette.status import HTTP_401_UNAUTHORIZED
@@ -48,7 +48,25 @@ if FIREBASE_CREDS_PATH is not None:
 
 api_key_header = APIKeyHeader(name="ndif-api-key", auto_error=False)
 
-async def api_key_auth(request : RequestModel, api_key: str = Security(api_key_header)):
+# Helper function to extract headers and client information
+def extract_request_metadata(raw_request: Request):
+    content_length = raw_request.headers.get('content-length')
+    
+    # Handle IP address, including proxy headers
+    ip_address = raw_request.client.host
+    forwarded_for = raw_request.headers.get('x-forwarded-for')
+    if forwarded_for:
+        ip_address = forwarded_for.split(',')[0]  # Take the first IP in the list
+
+    # Extract User-Agent
+    user_agent = raw_request.headers.get('user-agent')
+    
+    return ip_address, user_agent, int(content_length)
+
+async def api_key_auth(request : RequestModel, raw_request : Request, api_key: str = Security(api_key_header)):
+
+    # Extract metadata
+    ip_address, user_agent, content_length = extract_request_metadata(raw_request)
 
     # Set the id and time received of request.
     if not request.id:
@@ -59,6 +77,8 @@ async def api_key_auth(request : RequestModel, api_key: str = Security(api_key_h
     # TODO: Update the RequestModel to include additional fields (e.g. API key)
 
     gauge.update(request, api_key, ResponseModel.JobStatus.RECEIVED)
+
+    gauge.update_network(request.id, ip_address, user_agent, content_length)
 
     if FIREBASE_CREDS_PATH is not None:
         check_405b = False

--- a/telemetry/metrics/gauge.py
+++ b/telemetry/metrics/gauge.py
@@ -6,6 +6,8 @@ from nnsight.schema.Response import ResponseModel
 
 # Labels for the metrics
 request_labels = ('request_id', 'api_key', 'model_key', 'timestamp')
+network_labels = ('request_id', 'ip_address')
+
 
 class NDIFGauge:
     """
@@ -37,6 +39,8 @@ class NDIFGauge:
             instance = super(NDIFGauge, cls).__new__(cls)
             instance.service = service
             instance._gauge = instance._initialize_gauge()
+            if service != 'ray':  # Only initialize the network gauge if the service is not 'ray'
+                instance._network_gauge = instance._initialize_network_gauge()
             cls._instances[service] = instance
         return cls._instances[service]
 
@@ -47,6 +51,10 @@ class NDIFGauge:
             return RayGauge('request_status', description='Track status of requests', tag_keys=request_labels)
         else:
             return PrometheusGauge('request_status', 'Track status of requests', request_labels)
+
+    def _initialize_network_gauge(self):
+        """Initialize the network-related Gauge. Only used if the service is not 'ray'."""
+        return PrometheusGauge('network_data', 'Track network data of requests', network_labels)
 
     def update(self, request: RequestModel, api_key: str, status : ResponseModel.JobStatus) -> None:
         """
@@ -67,3 +75,19 @@ class NDIFGauge:
         else:
             # Prometheus Gauge API uses a more traditional labeling approach
             self._gauge.labels(**labels).set(numeric_status)
+
+    def update_network(self, request_id: str, ip_address: str, content_length: int) -> None:
+        """
+        Update the values of the network-related gauge.
+        Only applicable for services other than 'ray'.
+        """
+        if self.service == 'ray':
+            return  # Do nothing if the service is 'ray'
+        
+        network_labels = {
+            "request_id": request_id,
+            "ip_address": ip_address
+        }
+
+        # Set content length in the network gauge
+        self._network_gauge.labels(**network_labels).set(content_length)

--- a/telemetry/metrics/gauge.py
+++ b/telemetry/metrics/gauge.py
@@ -6,7 +6,7 @@ from nnsight.schema.Response import ResponseModel
 
 # Labels for the metrics
 request_labels = ('request_id', 'api_key', 'model_key', 'timestamp')
-network_labels = ('request_id', 'ip_address')
+network_labels = ('request_id', 'ip_address', 'user_agent')
 
 
 class NDIFGauge:
@@ -76,7 +76,7 @@ class NDIFGauge:
             # Prometheus Gauge API uses a more traditional labeling approach
             self._gauge.labels(**labels).set(numeric_status)
 
-    def update_network(self, request_id: str, ip_address: str, content_length: int) -> None:
+    def update_network(self, request_id: str, ip_address: str, user_agent: str, content_length: int) -> None:
         """
         Update the values of the network-related gauge.
         Only applicable for services other than 'ray'.
@@ -86,7 +86,8 @@ class NDIFGauge:
         
         network_labels = {
             "request_id": request_id,
-            "ip_address": ip_address
+            "ip_address": ip_address,
+            "user_agent": user_agent
         }
 
         # Set content length in the network gauge


### PR DESCRIPTION
This PR includes the following updates:

- Introduces a new `network_data` data source via a custom Prometheus gauge
- Adds the gauge to `api_key_auth()` (ensuring that the network data is logged regardless of whether the request was authenticated)

Currently, this data source is just scrapped by prometheus, and nothing is done with it explicitly, but it can be linked directly to the `request_status` data source via the `request_id` key.

Dependent on #44