### PR TITLE
Simple GPU memory metrics

### DIFF
--- a/compose/dev/docker-compose.yml
+++ b/compose/dev/docker-compose.yml
@@ -76,8 +76,6 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
       - grafana-storage:/var/lib/grafana
-      - ../../telemetry/grafana/provisioning:/etc/grafana/provisioning
-      - ../../telemetry/grafana/dashboards:/var/lib/grafana/dashboards
     depends_on:
       - prometheus
 

--- a/compose/dev/docker-compose.yml
+++ b/compose/dev/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     volumes:
       - /share/u/jadenfk/.cache/huggingface/hub:/root/.cache/huggingface/hub
       - ray-data:/tmp/ray/session_latest
-      - ../../telemetry/metrics:/src/metrics
       - /disk/u/jfiottok/.cache/huggingface/hub/:/root/.cache/huggingface/hub
       - /disk/u/jfiottok/wd/ndif/compose/prod/service_config.yml:/src/ray/config/service_config.yml
       - /disk/u/jfiottok/wd/ndif/compose/prod/ray_config.yml:/src/ray/config/ray_config.yml
@@ -39,23 +38,20 @@ services:
               count: 8
               capabilities: [ gpu ]
     environment:
+       - OBJECT_STORE_URL=localhost:27017
        - RAY_METRICS_EXPORT_PORT=8267
        - RAY_JOB_METRICS_EXPORT_PORT=8267
        - RAY_METRICS_GAUGE_EXPORT_INTERVAL_MS=1000
-       - PYTHONPATH=/src/logging:/src/metrics
        - LOKI_URL=http://localhost:3100/loki/api/v1/push
 
   api:
     image: api:latest
-    volumes:
-      - ../../telemetry/metrics:/src/metrics
     network_mode: "host"
     environment:
-      DATABASE_URL: mongodb://user:pass@localhost:27017
+      OBJECT_STORE_URL: localhost:27017
       RMQ_URL: amqp://guest:guest@localhost:5672/
       WORKERS: 1
       RAY_ADDRESS: ray://localhost:10001
-      PYTHONPATH: /src/logging:/src/metrics
       LOKI_URL: http://localhost:3100/loki/api/v1/push
       # FIREBASE_CREDS_PATH
 
@@ -80,6 +76,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ../../telemetry/grafana/provisioning:/etc/grafana/provisioning
+      - ../../telemetry/grafana/dashboards:/var/lib/grafana/dashboards
     depends_on:
       - prometheus
 

--- a/ray/deployments/distributed_model.py
+++ b/ray/deployments/distributed_model.py
@@ -256,8 +256,6 @@ class ModelDeployment:
 
             # Peak VRAM usage (in bytes) of current worker during execution
             gpu_mem = max_memory_allocated()
-            self.gauge.update(request=request, api_key=' ', status=ResponseModel.JobStatus.RUNNING, gpu_mem=gpu_mem)
-
 
             if self.head:
 
@@ -272,7 +270,7 @@ class ModelDeployment:
                     received=request.received,
                     status=ResponseModel.JobStatus.COMPLETED,
                     description="Your job has been completed.",
-                ).log(self.logger).update_gauge(self.gauge, request).respond(self.api_url, self.object_store)
+                ).log(self.logger).update_gauge(self.gauge, request, gpu_mem).respond(self.api_url, self.object_store)
 
         except Exception as exception:
 

--- a/ray/deployments/model.py
+++ b/ray/deployments/model.py
@@ -113,8 +113,6 @@ class ModelDeployment:
             # Peak VRAM usage during execution (in bytes)
             gpu_mem = max_memory_allocated()
 
-            self.gauge.update(request=request, api_key=' ', status=ResponseModel.JobStatus.COMPLETED, gpu_mem=gpu_mem)
-
             ResultModel(
                 id=request.id,
                 value=obj.remote_backend_postprocess_result(local_result),
@@ -127,7 +125,7 @@ class ModelDeployment:
                 received=request.received,
                 status=ResponseModel.JobStatus.COMPLETED,
                 description="Your job has been completed.",
-            ).log(self.logger).update_gauge(self.gauge, request).respond(self.api_url, self.object_store)
+            ).log(self.logger).update_gauge(self.gauge, request, gpu_mem).respond(self.api_url, self.object_store)
 
         except Exception as exception:
 

--- a/schema/Response.py
+++ b/schema/Response.py
@@ -140,8 +140,8 @@ class ResponseModel(_ResponseModel, StoredMixin):
 
         return self
 
-    def update_gauge(self, gauge: NDIFGauge, request: RequestModel):
-        gauge.update(request, " ", self.status)
+    def update_gauge(self, gauge: NDIFGauge, request: RequestModel, gpu_mem: int = 0) -> Self:
+        gauge.update(request, " ", self.status, gpu_mem)
         return self
 
     def blocking(self) -> bool:

--- a/telemetry/grafana/provisioning/datasources/prometheus.yml
+++ b/telemetry/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:9090
+    isDefault: true
+    editable: true

--- a/telemetry/metrics/gauge.py
+++ b/telemetry/metrics/gauge.py
@@ -5,7 +5,7 @@ from nnsight.schema.Request import RequestModel
 from nnsight.schema.Response import ResponseModel
 
 # Labels for the metrics
-request_labels = ('request_id', 'api_key', 'model_key', 'timestamp')
+request_labels = ('request_id', 'api_key', 'model_key', 'gpu_mem', 'timestamp')
 
 class NDIFGauge:
     """
@@ -48,7 +48,7 @@ class NDIFGauge:
         else:
             return PrometheusGauge('request_status', 'Track status of requests', request_labels)
 
-    def update(self, request: RequestModel, api_key: str, status : ResponseModel.JobStatus) -> None:
+    def update(self, request: RequestModel, api_key: str, status : ResponseModel.JobStatus, gpu_mem: int = 0) -> None:
         """
         Update the values of the gauge to reflect the current status of a request.
         Handles both Ray and Prometheus Gauge APIs.
@@ -58,6 +58,7 @@ class NDIFGauge:
             "request_id": request.id,
             "api_key": api_key,
             "model_key": request.model_key,
+            "gpu_mem": str(gpu_mem),
             "timestamp": str(request.received)  # Ensure timestamp is string for consistency
         }
 


### PR DESCRIPTION
The following PR introduces the following:

- A naive GPU memory tracking metric which uses `torch.cuda.max_memory_allocated` to determine the peak VRAM usage of a job.
- Instrumented for both `model` and `distributed_model` deployments

This approach naively assumes that the process running the job is for a single user request, it would not for instance work if batching multiple jobs through the same process.

Dependent on #44 
