### PR TITLE
NNsight timer to timeout jobs for distributed model. We usually do th…

### DIFF
--- a/ray/util.py
+++ b/ray/util.py
@@ -1,11 +1,23 @@
-import torch
 import os
+import time
+from concurrent.futures import TimeoutError
+from contextlib import AbstractContextManager
+from functools import wraps
+from typing import Callable
+
+import torch
+from torch.overrides import TorchFunctionMode
+
+from nnsight.patching import Patch, Patcher
 from nnsight.schema.format import functions
+from nnsight.tracing.Graph import Graph
+from nnsight.tracing.Node import Node
+
 
 def get_total_cudamemory_MBs(return_ids=False) -> int:
 
     cudamemory = 0
-    
+
     ids = []
 
     for device in range(torch.cuda.device_count()):
@@ -17,24 +29,95 @@ def get_total_cudamemory_MBs(return_ids=False) -> int:
             pass
 
     if return_ids:
-        
+
         return int(cudamemory), ids
 
     return int(cudamemory)
 
 
-def set_cuda_env_var(ids = None):
-    
+def set_cuda_env_var(ids=None):
+
     del os.environ["CUDA_VISIBLE_DEVICES"]
-    
+
     if ids == None:
-        
+
         _, ids = get_total_cudamemory_MBs(return_ids=True)
 
     os.environ["CUDA_VISIBLE_DEVICES"] = ",".join([str(x) for x in ids])
 
+
 def update_nnsight_print_function(new_function):
-    
+
     new_function.__name__ = functions.get_function_name(print)
-    
+
     functions.FUNCTIONS_WHITELIST[functions.get_function_name(print)] = new_function
+
+
+class NNsightTimer(AbstractContextManager):
+
+    class FunctionMode(TorchFunctionMode):
+
+        def __init__(self, timer: "NNsightTimer"):
+
+            self.timer = timer
+
+            super().__init__()
+
+        def __torch_function__(self, func, types, args=(), kwargs=None):
+
+            self.timer.check()
+
+            if kwargs is None:
+                kwargs = {}
+            return func(*args, **kwargs)
+
+    def __init__(self, timeout: float):
+
+        self.timeout = timeout
+        self.start: float = None
+
+        self.patcher = Patcher(
+            [
+                Patch(Node, self.wrap(Node.execute), "execute"),
+                Patch(Graph, self.wrap(Graph.execute), "execute"),
+            ]
+        )
+
+        self.fn_mode = NNsightTimer.FunctionMode(self)
+
+    def __enter__(self):
+
+        self.reset()
+
+        self.patcher.__enter__()
+        self.fn_mode.__enter__()
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+
+        self.patcher.__exit__(None, None, None)
+        self.fn_mode.__exit__(None, None, None)
+
+        if isinstance(exc_value, Exception):
+            raise exc_value
+
+    def reset(self):
+
+        self.start = time.time()
+
+    def wrap(self, fn: Callable):
+
+        @wraps(fn)
+        def inner(*args, **kwargs):
+
+            self.check()
+
+            return fn(*args, **kwargs)
+
+        return inner
+
+    def check(self):
+
+        if time.time() - self.start > self.timeout:
+            raise TimeoutError()


### PR DESCRIPTION
…is via a thread but you cant run torch.distributed in a thread. Therefore we hook nnsight execution and torch function mode to check the execution time as most of the computation time is  from gpu operations, the effect is fairly minimal.