### PR TITLE
Added remote method to Controller deployment to restart an applicatio…

### DIFF
--- a/ray/deployments/controller.py
+++ b/ray/deployments/controller.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from typing import Dict
 
 from pydantic import BaseModel
@@ -38,10 +39,18 @@ class ControllerDeployment:
 
         self.state.redeploy()
 
-    def redeploy(self):
+    async def redeploy(self):
         """Redeploy serve configuration using service_config.yml"""
 
         self.state.redeploy()
+
+    async def restart(self, name: str):
+        
+        self.state.name_to_application[name].runtime_env["env_vars"]["restart_hash"] = (
+            str(uuid.uuid4())
+        )
+
+        self.state.apply()
 
 
 class ControllerDeploymentArgs(BaseModel):

--- a/ray/raystate.py
+++ b/ray/raystate.py
@@ -56,7 +56,11 @@ class RayState:
         self.api_url = api_url
 
         self.runtime_context = ray.get_runtime_context()
-        self.ray_dashboard_url = f"http://{self.runtime_context.worker.node.address_info['webui_url']}"
+        self.ray_dashboard_url = (
+            f"http://{self.runtime_context.worker.node.address_info['webui_url']}"
+        )
+
+        self.name_to_application: Dict[str, ServeApplicationSchema] = {}
 
     def load_from_disk(self):
 
@@ -64,9 +68,7 @@ class RayState:
             self.ray_config = ServeDeploySchema(**yaml.safe_load(file))
 
         with open(self.service_config_path, "r") as file:
-            self.service_config = ServiceConfigurationSchema(
-                **yaml.safe_load(file)
-            )
+            self.service_config = ServiceConfigurationSchema(**yaml.safe_load(file))
 
     def redeploy(self):
 
@@ -80,10 +82,15 @@ class RayState:
         self.apply()
 
     def apply(self) -> None:
-
+        
         ServeSubmissionClient(self.ray_dashboard_url).deploy_applications(
             self.ray_config.dict(exclude_unset=True),
         )
+
+    def add(self, application: ServeApplicationSchema):
+
+        self.ray_config.applications.append(application)
+        self.name_to_application[application.name] = application
 
     def add_request_app(self) -> None:
         application = ServeApplicationSchema(
@@ -107,7 +114,7 @@ class RayState:
             ).model_dump(),
         )
 
-        self.ray_config.applications.append(application)
+        self.add(application)
 
     def add_model_app(
         self, model_config: ServiceConfigurationSchema.ModelConfigurationSchema
@@ -118,12 +125,8 @@ class RayState:
         model_config.args["model_key"] = model_config.model_key
         model_config.args["api_url"] = self.api_url
         model_config.args["object_store_url"] = self.object_store_url
-        model_config.args["object_store_access_key"] = (
-            self.object_store_access_key
-        )
-        model_config.args["object_store_secret_key"] = (
-            self.object_store_secret_key
-        )
+        model_config.args["object_store_access_key"] = self.object_store_access_key
+        model_config.args["object_store_secret_key"] = self.object_store_secret_key
 
         application = ServeApplicationSchema(
             name=f"Model:{model_key}",
@@ -138,6 +141,7 @@ class RayState:
                 )
             ],
             args=model_config.args,
+            runtime_env={"env_vars": {"restart_hash": ""}},
         )
 
-        self.ray_config.applications.append(application)
+        self.add(application)


### PR DESCRIPTION
…n. It updates an unused env var in the chosen applications config and then redeploys. This causes Ray to restart the Deployment.

Model deployments trigger this remote method with their application name when they hit a CUDA device side assert error as its the only way to uncorrupt its cuda runtime