### PR TITLE
Added patches for working on deltai

### DIFF
--- a/ray/deployments/request.py
+++ b/ray/deployments/request.py
@@ -23,14 +23,15 @@ class RequestDeployment(BaseDeployment):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.sio.connect(
-            self.api_url,
-            socketio_path="/ws/socket.io",
-            transports=["websocket"],
-            wait_timeout=10,
-        )
-
     def __call__(self, request: BackendRequestModel):
+
+        if not self.sio.connected:
+            self.sio.connect(
+                self.api_url,
+                socketio_path="/ws/socket.io",
+                transports=["websocket"],
+                wait_timeout=100000,
+            )
 
         try:
 

--- a/ray/distributed/util.py
+++ b/ray/distributed/util.py
@@ -3,6 +3,7 @@ from functools import wraps
 from typing import Any, NamedTuple
 
 import torch
+import os
 
 from safetensors.torch import load_file
 from torch.distributed._tensor import DTensor, Replicate
@@ -11,6 +12,21 @@ from transformers.utils.hub import cached_file
 
 from nnsight import util
 from nnsight.intervention.protocols import InterventionProtocol
+
+from accelerate import load_checkpoint_and_dispatch
+from accelerate.utils import modeling
+from accelerate.utils.imports import (
+    is_mlu_available,
+    is_mps_available,
+    is_musa_available,
+    is_npu_available,
+    is_peft_available,
+    is_torch_xla_available,
+    is_xpu_available,
+)
+from accelerate.utils.modeling import check_device_same, clear_device_cache
+from accelerate.utils import modeling
+from safetensors.torch import load_file
 
 
 def load_hf_model_from_cache(model: torch.nn.Module, repo_id: str):
@@ -31,7 +47,17 @@ def load_hf_model_from_cache(model: torch.nn.Module, repo_id: str):
         pbar.set_postfix({"Current shard": shard_file})
 
         # Get path to shard
-        state_dict = load_file(shard_path, device="cuda")
+        state_dict = load_file(shard_path, device="cpu")
+
+        torch.distributed.barrier()
+
+        if os.environ.get('DELETE_MODEL_SHARDS', '0') == '1' and os.environ['CUDA_VISIBLE_DEVICES'][0] == '0':
+            binary_path = os.path.realpath(shard_path)
+            os.remove(binary_path)
+            os.remove(shard_path)
+
+
+        state_dict = {key: value.cuda() for key, value in state_dict.items()}
 
         model.load_state_dict(state_dict, strict=False, assign=True)
 
@@ -93,3 +119,281 @@ def patch_intervention_protocol() -> None:
         return intervene_wrapper
 
     InterventionProtocol.intervene = wrap(InterventionProtocol.intervene)
+
+
+def to_full_tensor(data: Any) -> Any:
+
+    return util.apply(data, lambda x: x.full_tensor(), DTensor)
+
+
+def set_module_tensor_to_device(
+    module: torch.nn.Module,
+    tensor_name: str,
+    device,
+    value=None,
+    dtype=None,
+    fp16_statistics=None,
+    tied_params_map=None,
+):
+    """
+    A helper function to set a given tensor (parameter of buffer) of a module on a specific device (note that doing
+    `param.to(device)` creates a new tensor not linked to the parameter, which is why we need this function).
+
+    Args:
+        module (`torch.nn.Module`):
+            The module in which the tensor we want to move lives.
+        tensor_name (`str`):
+            The full name of the parameter/buffer.
+        device (`int`, `str` or `torch.device`):
+            The device on which to set the tensor.
+        value (`torch.Tensor`, *optional*):
+            The value of the tensor (useful when going from the meta device to any other device).
+        dtype (`torch.dtype`, *optional*):
+            If passed along the value of the parameter will be cast to this `dtype`. Otherwise, `value` will be cast to
+            the dtype of the existing parameter in the model.
+        fp16_statistics (`torch.HalfTensor`, *optional*):
+            The list of fp16 statistics to set on the module, used for 8 bit model serialization.
+        tied_params_map (Dict[int, Dict[torch.device, torch.Tensor]], *optional*, defaults to `None`):
+            A map of current data pointers to dictionaries of devices to already dispatched tied weights. For a given
+            execution device, this parameter is useful to reuse the first available pointer of a shared weight on the
+            device for all others, instead of duplicating memory.
+    """
+    # Recurse if needed
+    if "." in tensor_name:
+        splits = tensor_name.split(".")
+        for split in splits[:-1]:
+            new_module = getattr(module, split)
+            if new_module is None:
+                raise ValueError(f"{module} has no attribute {split}.")
+            module = new_module
+        tensor_name = splits[-1]
+
+    if (
+        tensor_name not in module._parameters
+        and tensor_name not in module._buffers
+    ):
+        raise ValueError(
+            f"{module} does not have a parameter or a buffer named {tensor_name}."
+        )
+    is_buffer = tensor_name in module._buffers
+    old_value = getattr(module, tensor_name)
+
+    # Treat the case where old_value (or a custom `value`, typically offloaded to RAM/disk) belongs to a tied group, and one of the weight
+    # in the tied group has already been dispatched to the device, by avoiding reallocating memory on the device and just copying the pointer.
+    if (
+        value is not None
+        and tied_params_map is not None
+        and value.data_ptr() in tied_params_map
+        and device in tied_params_map[value.data_ptr()]
+    ):
+        module._parameters[tensor_name] = tied_params_map[value.data_ptr()][
+            device
+        ]
+        return
+    elif (
+        tied_params_map is not None
+        and old_value.data_ptr() in tied_params_map
+        and device in tied_params_map[old_value.data_ptr()]
+    ):
+        module._parameters[tensor_name] = tied_params_map[old_value.data_ptr()][
+            device
+        ]
+        return
+
+    if (
+        old_value.device == torch.device("meta")
+        and device not in ["meta", torch.device("meta")]
+        and value is None
+    ):
+        raise ValueError(
+            f"{tensor_name} is on the meta device, we need a `value` to put in on {device}."
+        )
+
+    param = (
+        module._parameters[tensor_name]
+        if tensor_name in module._parameters
+        else None
+    )
+    param_cls = type(param)
+
+    if value is not None:
+        # We can expect mismatches when using bnb 4bit since Params4bit will reshape and pack the weights.
+        # In other cases, we want to make sure we're not loading checkpoints that do not match the config.
+        if (
+            old_value.shape != value.shape
+            and param_cls.__name__ != "Params4bit"
+        ):
+            raise ValueError(
+                f'Trying to set a tensor of shape {value.shape} in "{tensor_name}" (which has shape {old_value.shape}), this looks incorrect.'
+            )
+
+        if dtype is None:
+            # For compatibility with PyTorch load_state_dict which converts state dict dtype to existing dtype in model
+            value = value.to(old_value.dtype)
+        elif not str(value.dtype).startswith(
+            ("torch.uint", "torch.int", "torch.bool")
+        ):
+            value = value.to(dtype)
+
+    device_quantization = None
+    with torch.no_grad():
+        # leave it on cpu first before moving them to cuda
+        # # fix the case where the device is meta, we don't want to put it on cpu because there is no data =0
+        if (
+            param is not None
+            and param.device.type != "cuda"
+            and torch.device(device).type == "cuda"
+            and param_cls.__name__ in ["Int8Params", "FP4Params", "Params4bit"]
+        ):
+            device_quantization = device
+            device = "cpu"
+        # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).
+        if isinstance(device, int):
+            if is_npu_available():
+                device = f"npu:{device}"
+            elif is_mlu_available():
+                device = f"mlu:{device}"
+            elif is_musa_available():
+                device = f"musa:{device}"
+            elif is_xpu_available():
+                device = f"xpu:{device}"
+        if "xpu" in str(device) and not is_xpu_available():
+            raise ValueError(
+                f'{device} is not available, you should use device="cpu" instead'
+            )
+        if value is None:
+            new_value = old_value.to(device)
+            if dtype is not None and device in ["meta", torch.device("meta")]:
+                if not str(old_value.dtype).startswith(
+                    ("torch.uint", "torch.int", "torch.bool")
+                ):
+                    new_value = new_value.to(dtype)
+
+                if not is_buffer:
+                    module._parameters[tensor_name] = param_cls(
+                        new_value, requires_grad=old_value.requires_grad
+                    )
+        elif isinstance(value, torch.Tensor):
+            new_value = value.to(device)
+        else:
+            new_value = torch.tensor(value, device=device)
+        if device_quantization is not None:
+            device = device_quantization
+        if is_buffer:
+            module._buffers[tensor_name] = new_value
+        elif value is not None or not check_device_same(
+            torch.device(device), module._parameters[tensor_name].device
+        ):
+            param_cls = type(module._parameters[tensor_name])
+            kwargs = module._parameters[tensor_name].__dict__
+            if param_cls.__name__ in ["Int8Params", "FP4Params", "Params4bit"]:
+                if (
+                    param_cls.__name__ == "Int8Params"
+                    and new_value.dtype == torch.float32
+                ):
+                    # downcast to fp16 if any - needed for 8bit serialization
+                    new_value = new_value.to(torch.float16)
+                # quantize module that are going to stay on the cpu so that we offload quantized weights
+                if device == "cpu" and param_cls.__name__ == "Int8Params":
+                    new_value = (
+                        param_cls(
+                            new_value,
+                            requires_grad=old_value.requires_grad,
+                            **kwargs,
+                        )
+                        .to(0)
+                        .to("cpu")
+                    )
+                    new_value.CB = new_value.CB.to("cpu")
+                    new_value.SCB = new_value.SCB.to("cpu")
+                else:
+                    new_value = param_cls(
+                        new_value,
+                        requires_grad=old_value.requires_grad,
+                        **kwargs,
+                    ).to(device)
+            elif param_cls.__name__ in ["QTensor", "QBitsTensor"]:
+                new_value = torch.nn.Parameter(
+                    new_value, requires_grad=old_value.requires_grad
+                ).to(device)
+            else:
+                new_value = param_cls(
+                    new_value, requires_grad=old_value.requires_grad
+                ).to(device)
+
+            module._parameters[tensor_name] = new_value
+            if fp16_statistics is not None:
+                module._parameters[tensor_name].SCB = fp16_statistics.to(device)
+                del fp16_statistics
+            # as we put the weight to meta, it doesn't have SCB attr anymore. make sure that it is not a meta weight
+            if (
+                module.__class__.__name__ == "Linear8bitLt"
+                and getattr(module.weight, "SCB", None) is None
+                and str(module.weight.device) != "meta"
+            ):
+                # quantize only if necessary
+                device_index = (
+                    torch.device(device).index
+                    if torch.device(device).type == "cuda"
+                    else None
+                )
+                if (
+                    not getattr(module.weight, "SCB", None)
+                    and device_index is not None
+                ):
+                    if (
+                        module.bias is not None
+                        and module.bias.device.type != "meta"
+                    ):
+                        # if a bias exists, we need to wait until the bias is set on the correct device
+                        module = module.cuda(device_index)
+                    elif module.bias is None:
+                        # if no bias exists, we can quantize right away
+                        module = module.cuda(device_index)
+            elif (
+                module.__class__.__name__ == "Linear4bit"
+                and getattr(module.weight, "quant_state", None) is None
+                and str(module.weight.device) != "meta"
+            ):
+                # quantize only if necessary
+                device_index = (
+                    torch.device(device).index
+                    if torch.device(device).type == "cuda"
+                    else None
+                )
+                if (
+                    not getattr(module.weight, "quant_state", None)
+                    and device_index is not None
+                ):
+                    module.weight = module.weight.cuda(device_index)
+    # clean pre and post foward hook
+    if device != "cpu":
+        clear_device_cache()
+
+    # When handling tied weights, we update tied_params_map to keep track of the tied weights that have already been allocated on the device in
+    # order to avoid duplicating memory, see above.
+    if (
+        tied_params_map is not None
+        and old_value.data_ptr() in tied_params_map
+        and device not in tied_params_map[old_value.data_ptr()]
+    ):
+        tied_params_map[old_value.data_ptr()][device] = new_value
+    elif (
+        value is not None
+        and tied_params_map is not None
+        and value.data_ptr() in tied_params_map
+        and device not in tied_params_map[value.data_ptr()]
+    ):
+        tied_params_map[value.data_ptr()][device] = new_value
+        
+        
+    #### PATCH #######################################
+    
+    for hook in module._load_state_dict_post_hooks.values():
+                
+        hook(module, None)
+
+
+def patch_accelerate():
+    
+    modeling.set_module_tensor_to_device = set_module_tensor_to_device

--- a/services/api/src/app.py
+++ b/services/api/src/app.py
@@ -78,6 +78,8 @@ Instrumentator().instrument(app).expose(app)
 
 api_key_header = APIKeyHeader(name="ndif-api-key", auto_error=False)
 
+# Create a dummy request to ensure app handle is created
+serve.get_app_handle("Request").remote({})
 
 @app.post("/request")
 async def request(


### PR DESCRIPTION
Added three quick changes for compatibility with Delta AI cluster.

These include:

1. Support optionally deleting model shards for distributed deployments.
- This can be done via the `DELETE_MODEL_SHARDS` env variable (setting to 1)
2. Have Socket IO connect to API in `RequestDeployment.__call__()`
- This was previously done in `RequestDeployment.__init__()`, which caused race conditions when the Ray head was spun up before the API.
3. Have fake request made to RequestDeployment from API on start
- This ensures that an app handle for the RequestDeployment is created before any user requests are made (with the Delta AI setup, this process can be quite slow and logs undesired information to the user).