### PR TITLE
Added option to configure tags for docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ DEFAULT_ENV ?= dev
 # Configs for local nnsight installation
 DEV_NNS ?= False
 NNS_PATH ?= ~/nnsight
+TAG ?= latest
 
 # Function to check if the environment is valid
 check_env = $(if $(filter $(1),$(VALID_ENVS)),,$(error Invalid environment '$(1)'. Use one of: $(VALID_ENVS)))
@@ -24,15 +25,15 @@ set_env = $(eval ENV := $(if $(filter $(words $(MAKECMDGOALS)),1),$(DEFAULT_ENV)
           $(if $(filter $(words $(MAKECMDGOALS)),1),$(info Using default environment: $(DEFAULT_ENV)),)
 
 build_base:
-	docker build --no-cache -t ndif_base:latest -f docker/dockerfile.base .
+	docker build --no-cache -t ndif_base:$(TAG) -f docker/dockerfile.base .
 
 build_conda:
-	docker build --no-cache --build-arg NAME=$(NAME) -t $(NAME)_conda:latest -f docker/dockerfile.conda .
+	docker build --no-cache --build-arg NAME=$(NAME) --build-arg TAG=$(TAG) -t $(NAME)_conda:$(TAG) -f docker/dockerfile.conda .
 
 build_service:
 	cp docker/helpers/check_and_update_env.sh ./
 	tar -hczvf src.tar.gz --directory=services/$(NAME) src
-	docker build --no-cache --build-arg NAME=$(NAME) -t $(NAME):latest -f docker/dockerfile.service  . 
+	docker build --no-cache --build-arg NAME=$(NAME) --build-arg TAG=$(TAG) -t $(NAME):$(TAG) -f docker/dockerfile.service  . 
 	rm src.tar.gz
 	rm check_and_update_env.sh
 

--- a/docker/dockerfile.conda
+++ b/docker/dockerfile.conda
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE=ndif_base
-FROM ${BASE_IMAGE}:latest
+ARG TAG=latest
+FROM ${BASE_IMAGE}:${TAG}
 
 # Update environment with service-specific dependencies
 ARG NAME

--- a/docker/dockerfile.service
+++ b/docker/dockerfile.service
@@ -1,5 +1,6 @@
 ARG NAME
-FROM ${NAME}_conda:latest
+ARG TAG=latest
+FROM ${NAME}_conda:${TAG}
 
 # New build stage, so need to redeclare NAME
 ARG NAME


### PR DESCRIPTION
## Description

This PR introduces configurable Docker image tagging in the NDIF build system. Previously, all Docker images were hardcoded to use the `latest` tag, limiting flexibility in version management and deployment scenarios.

### Changes

- Introduced configurable image tagging across the build system:
  - Added `TAG` variable to Makefile (defaults to `latest`)
  - Modified `dockerfile.conda` and `dockerfile.service` to accept `TAG` as a build argument
  - Updated Docker build commands to utilize the `TAG` variable

### Usage

Images can now be built with custom tags in two ways:
1. Setting `TAG` in the environment:

```
export TAG=1.0.0
make build_service NAME=api
```


2. Passing `TAG` directly to make:

```
make build_service NAME=api TAG=1.0.0
```