### PR TITLE
Fix: Prevent duplicate logging messages from nnsight_remote

### DIFF
--- a/src/common/logging/logger.py
+++ b/src/common/logging/logger.py
@@ -153,11 +153,26 @@ def load_logger(service_name: str="", logger_name: str="") -> logging.Logger:
         datefmt="%Y-%m-%d %H:%M:%S"
     )
     
+    # Check for nnsight loggers
+    nnsight_logger_names = ['nnsight', 'nnsight_remote']
+    has_nnsight_console_handler = False
+    for name in nnsight_logger_names:
+        nnsight_logger = logging.getLogger(name)
+        if nnsight_logger.hasHandlers():
+            for handler in nnsight_logger.handlers:
+                if isinstance(handler, logging.StreamHandler):
+                    has_nnsight_console_handler = True
+                    break
+        if has_nnsight_console_handler:
+            break
+
     # Set up console handler for local debugging
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(console_formatter)
-    console_handler.setLevel(logging.DEBUG)
-    logger.addHandler(console_handler)
+    # Only add handler if nnsight hasn't already set up a console handler
+    if not has_nnsight_console_handler:
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(console_formatter)
+        console_handler.setLevel(logging.DEBUG)
+        logger.addHandler(console_handler)
 
     # Set up Loki handler if URL is configured
     if LOKI_URL is not None:


### PR DESCRIPTION
The nnsight library configures its own logger (often named 'nnsight_remote'). When the application's `load_logger` function was also called, it would add a second console handler, leading to duplicated log messages:

```
2025-05-31 14:14:05,658 1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - RECEIVED: Your job has been received and is waiting approval.
INFO:nnsight_remote:1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - RECEIVED: Your job has been received and is waiting approval.
2025-05-31 14:14:05,844 1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - APPROVED: Your job was approved and is waiting to be run.
INFO:nnsight_remote:1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - APPROVED: Your job was approved and is waiting to be run.
2025-05-31 14:14:06,111 1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - RUNNING: Your job has started running.
INFO:nnsight_remote:1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - RUNNING: Your job has started running.
2025-05-31 14:14:50,641 1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - COMPLETED: Your job has been completed.
INFO:nnsight_remote:1338453b-e6b7-4b7d-8ee5-dfcc62f49017 - COMPLETED: Your job has been completed.
```

This commit modifies `src/common/logging/logger.py` so that the `load_logger` function checks if a logger named 'nnsight' or 'nnsight_remote' already has a `StreamHandler` configured. If such a handler exists, `load_logger` will not add its own console handler, thereby preventing the duplication of log messages.