### PR TITLE
Scrape Redis metrics

### DIFF
--- a/compose/dev/docker-compose.yml
+++ b/compose/dev/docker-compose.yml
@@ -4,6 +4,14 @@ services:
     ports:
       - ${DEV_BROKER_PORT}:${BROKER_INTERNAL_PORT}
 
+  redis_exporter:
+    image: bitnami/redis-exporter
+    network_mode: "host"
+    environment:
+      - REDIS_ADDR=redis://localhost:${DEV_BROKER_PORT}
+    depends_on:
+      - message_broker
+
   minio:
     image: minio/minio:${MINIO_VERSION}
     command: server /data

--- a/telemetry/prometheus/prometheus.yml
+++ b/telemetry/prometheus/prometheus.yml
@@ -9,8 +9,9 @@ scrape_configs:
   - job_name: 'combined_metrics' # Merges metrics from FastAPI and Ray together (needed for Grafana to group metrics from a single request together).
     static_configs:
       - targets: 
-        - localhost:5000  # FastAPI - Prod
-        - localhost:5001 # FastAPI - Dev
+        - localhost:5001 # FastAPI (API)
+        - localhost:6001 # FastAPI (Queue)
+        - localhost:9121 # Redis exporter
     file_sd_configs:
       - files:
         - '/tmp/ray/prom_metrics_service_discovery.json' # Contains dynamically updated list of ports & IP addresses of all the Ray nodes.


### PR DESCRIPTION
Scrape metrics from Redis using the RedisExporter service. Configured to be scraped by Prometheus (for now)