### PR TITLE
Typing "fix"

### DIFF
--- a/src/common/schema/request.py
+++ b/src/common/schema/request.py
@@ -76,7 +76,7 @@ class BackendRequestModel(ObjectStorageMixin):
         return BackendRequestModel(
             id=REQUEST_ID(request.headers.get("ndif-request_id")),
             request=request.body(),
-            model_key=MODEL_KEY(headers.get("nnsight-model-key")),
+            model_key=headers.get("nnsight-model-key") if headers.get("nnsight-model-key") else None,
             session_id=SESSION_ID(headers.get("ndif-session_id")) if headers.get("ndif-session_id") else None,
             zlib=headers.get("nnsight-zlib", True),
             last_status_time=sent,


### PR DESCRIPTION
No longer type checks the nnsight-model-key header directly, instead defers to the downstream call to `verify_nnsight_version()`.