### PR TITLE
Add DeploymentConfig schema for per-deployment configuration

### DIFF
--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -4,6 +4,7 @@ import click
 import ray
 import asyncio
 
+from src.common.schema.deployment_config import DeploymentConfig
 from ..lib.util import get_controller_actor_handle, get_model_key, notify_dispatcher
 from ..lib.checks import check_prerequisites
 from ..lib.session import get_env
@@ -49,7 +50,7 @@ def deploy(checkpoint: str, revision: str, dedicated: bool, ray_address: str, br
         controller = get_controller_actor_handle()
 
         click.echo(f"Deploying {model_key}...")
-        object_ref = controller._deploy.remote(model_keys=[model_key], dedicated=dedicated)
+        object_ref = controller._deploy.remote({model_key: DeploymentConfig(dedicated=dedicated)})
         results = ray.get(object_ref)
         result_status = results["result"][model_key]
 

--- a/src/common/schema/__init__.py
+++ b/src/common/schema/__init__.py
@@ -1,3 +1,4 @@
+from .deployment_config import DeploymentConfig
 from .request import BackendRequestModel
 from .response import BackendResponseModel
 from .result import BackendResultModel

--- a/src/common/schema/deployment_config.py
+++ b/src/common/schema/deployment_config.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel
+
+from ..types import MODEL_KEY
+
+
+class DeploymentConfig(BaseModel):
+    """Configuration for a model deployment."""
+
+    dedicated: bool = False
+    padding_factor: Optional[float] = None
+    execution_timeout_seconds: Optional[float] = None
+
+    @staticmethod
+    def normalize(
+        deployments: Union[
+            MODEL_KEY,
+            List[MODEL_KEY],
+            Dict[MODEL_KEY, "DeploymentConfig"],
+        ],
+    ) -> Dict[MODEL_KEY, "DeploymentConfig"]:
+        """Normalize various input formats into a dict of model_key -> DeploymentConfig.
+
+        Accepts:
+            - A single model key string
+            - A list of model key strings
+            - A dict mapping model key strings to DeploymentConfig instances
+
+        Returns:
+            A dict mapping model keys to DeploymentConfig instances.
+        """
+        if isinstance(deployments, dict):
+            return deployments
+
+        if isinstance(deployments, str):
+            deployments = [deployments]
+
+        return {key: DeploymentConfig() for key in deployments}

--- a/src/services/ray/src/ray/deployments/controller/cluster/cluster.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/cluster.py
@@ -9,6 +9,7 @@ from ray._private.state import GlobalState
 from ray._raylet import GcsClientOptions
 from ray.util.state import list_nodes
 
+from .....schema.deployment_config import DeploymentConfig
 from .....types import MODEL_KEY, NODE_ID
 from .evaluator import ModelEvaluator
 from .node import CandidateLevel, Node, Resources
@@ -21,10 +22,12 @@ class Cluster:
         self,
         minimum_deployment_time_seconds: float = None,
         model_cache_percentage: float = 0.5,
+        default_padding_factor: float = 0.15,
     ):
         self.nodes: Dict[NODE_ID, Node] = {}
 
-        self.evaluator = ModelEvaluator()
+        self.default_padding_factor = default_padding_factor
+        self.evaluator = ModelEvaluator(padding_factor=default_padding_factor)
 
         self._state = None
 
@@ -81,8 +84,8 @@ class Cluster:
                 gpu_type = "TEST"
                 # gpu_type = node.resources_total["GPU_TYPE"]
                 gpu_memory_bytes = (
-                    (node.resources_total["cuda_memory_bytes"]) / total_gpus
-                )
+                    node.resources_total["cuda_memory_bytes"]
+                ) / total_gpus
                 cpu_memory_bytes = (
                     node.resources_total["cpu_memory_bytes"]
                     * self.model_cache_percentage
@@ -113,32 +116,33 @@ class Cluster:
 
                 logger.info(f"=> Node {node_id} removed from cluster")
 
-    def deploy(self, model_keys: List[MODEL_KEY], dedicated: Optional[bool] = False):
+    def deploy(self, configs: Dict[MODEL_KEY, DeploymentConfig]):
         """
         Deploy models on the cluster. This updates our internal state of the cluster.
 
         Args:
-            model_keys (List[MODEL_KEY]): List of model keys to deploy
-            dedicated (Optional[bool], optional): Whether to deploy the models as dedicated. Defaults to False.
+            configs: Dict mapping model keys to their DeploymentConfig.
 
         Returns:
-            Dict[MODEL_KEY, str]: Dictionary of model keys and their deployment status
+            (results, change) tuple where:
+            - results: dict with "result" mapping model_key to status and "evictions" set
+            - change: bool indicating if cluster state changed
         """
 
         logger.info(
-            f"Cluster deploying models: {model_keys}, dedicated: {dedicated}..."
+            f"Cluster deploying models: {[(key, cfg.dedicated) for key, cfg in configs.items()]}..."
         )
 
         results = {"result": {}, "evictions": set()}
 
         change = False
 
-        # First get the size of the models in bytes
-        model_sizes_in_bytes = {
-            model_key: self.evaluator(model_key) for model_key in model_keys
-        }
+        all_model_keys = set(configs.keys())
 
-        for model_key, size_in_bytes in list(model_sizes_in_bytes.items()):
+        # First get the size of the models in bytes
+        evaluated_configs = []
+        for model_key, config in configs.items():
+            size_in_bytes = self.evaluator(model_key, padding_factor=config.padding_factor)
             if isinstance(size_in_bytes, Exception):
                 tb = "".join(
                     traceback.format_exception(
@@ -146,35 +150,35 @@ class Cluster:
                     )
                 )
                 logger.error(f"=> Model {model_key} failed to evaluate\n{tb}")
-
-                del model_sizes_in_bytes[model_key]
-
                 results["result"][model_key] = f"{size_in_bytes}\n{tb}"
+            else:
+                evaluated_configs.append((model_key, config, size_in_bytes))
 
-        # If this is a new dedicated set of models, we need to evict the dedicated deployments not found in the new set.
-        if dedicated:
+        # If any config is dedicated, evict deprecated dedicated deployments not in the new set.
+        has_dedicated = any(cfg.dedicated for _, cfg, _ in evaluated_configs)
+        if has_dedicated:
             logger.info("=> Checking to evict deprecated dedicated deployments...")
 
             for node in self.nodes.values():
                 for model_key, deployment in list(node.deployments.items()):
-                    if deployment.dedicated and model_key not in model_sizes_in_bytes:
+                    if deployment.dedicated and model_key not in all_model_keys:
                         logger.info(
                             f"==> Evicting deprecated dedicated deployment {model_key} from {node.name}"
                         )
 
                         results["evictions"].add(model_key)
 
-                        node.evict(model_key, exclude=set(model_keys))
+                        node.evict(model_key, exclude=all_model_keys)
 
                         change = True
 
         # Sort models by size in descending order (deploy biggest ones first)
-        sorted_models = sorted(
-            model_sizes_in_bytes.items(), key=lambda x: x[1], reverse=True
-        )
+        sorted_configs = sorted(evaluated_configs, key=lambda x: x[2], reverse=True)
 
         # For each model to deploy, find the best node to deploy it on, if possible.
-        for model_key, size_in_bytes in sorted_models:
+        for model_key, config, size_in_bytes in sorted_configs:
+            dedicated = config.dedicated
+
             logger.info(
                 f"=> Analyzing deployment of {model_key} with size {size_in_bytes}..."
             )
@@ -241,7 +245,8 @@ class Cluster:
                     candidate,
                     size_in_bytes,
                     dedicated=dedicated,
-                    exclude=set(model_keys),
+                    exclude=all_model_keys,
+                    execution_timeout_seconds=config.execution_timeout_seconds,
                 )
 
                 results["evictions"].update(candidate.evictions)
@@ -276,7 +281,7 @@ class Cluster:
                         "status": "evicted",
                         "node": node.name,
                         "freed_gpus": len(deployment.gpus),
-                        "freed_memory_gbs": deployment.size_bytes / 1024 / 1024 / 1024
+                        "freed_memory_gbs": deployment.size_bytes / 1024 / 1024 / 1024,
                     }
                     change = True
                     found = True

--- a/src/services/ray/src/ray/deployments/controller/cluster/deployment.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/deployment.py
@@ -30,6 +30,7 @@ class Deployment:
         size_bytes: int,
         dedicated: bool = False,
         node_id: str = None,
+        execution_timeout_seconds: float | None = None,
     ):
         self.model_key = model_key
         self.deployment_level = deployment_level
@@ -37,6 +38,7 @@ class Deployment:
         self.size_bytes = size_bytes
         self.dedicated = dedicated
         self.node_id = node_id
+        self.execution_timeout_seconds = execution_timeout_seconds
         self.deployed = time.time()
 
     @property
@@ -57,6 +59,7 @@ class Deployment:
             "size_bytes": self.size_bytes,
             "dedicated": self.dedicated,
             "node_id": self.node_id,
+            "execution_timeout_seconds": self.execution_timeout_seconds,
             "deployed": self.deployed,
         }
 

--- a/src/services/ray/src/ray/deployments/controller/cluster/evaluator.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/evaluator.py
@@ -11,8 +11,8 @@ logger = logging.getLogger("ndif")
 
 
 class CacheEntry:
-    def __init__(self, size_in_bytes: int, n_params: int, config: str, revision: str):
-        self.size_in_bytes = size_in_bytes
+    def __init__(self, base_size_in_bytes: int, n_params: int, config: str, revision: str):
+        self.base_size_in_bytes = base_size_in_bytes
         self.n_params = n_params
         self.config = config
         self.revision = revision
@@ -35,7 +35,7 @@ class ModelEvaluator:
         return {
             "cache": {
                 key: {
-                    "size_in_bytes": value.size_in_bytes,
+                    "base_size_in_bytes": value.base_size_in_bytes,
                     "config": value.config,
                 }
                 for key, value in self.cache.items()
@@ -44,44 +44,43 @@ class ModelEvaluator:
             "dtype": str(torch.get_default_dtype()),
         }
 
-    def __call__(self, model_key: MODEL_KEY) -> Union[float, Exception]:
-        if model_key in self.cache:
-            logger.info(
-                f"=> Model {model_key} already in evaluation cache. Size: {self.cache[model_key].size_in_bytes}"
+    def __call__(self, model_key: MODEL_KEY, padding_factor: float | None = None) -> Union[float, Exception]:
+        effective_padding = padding_factor if padding_factor is not None else self.padding_factor
+
+        if model_key not in self.cache:
+            try:
+                meta_model = RemoteableMixin.from_model_key(
+                    model_key,
+                    dispatch=False,
+                    torch_dtype=torch.bfloat16,
+                )
+
+            except Exception as exception:
+                return exception
+
+            param_size = 0
+            n_params = 0
+            for param in meta_model._model.parameters():
+                param_size += param.nelement() * param.element_size()
+                n_params += param.nelement()
+            buffer_size = 0
+            for buffer in meta_model._model.buffers():
+                buffer_size += buffer.nelement() * buffer.element_size()
+
+            base_size_bytes = param_size + buffer_size
+
+            self.cache[model_key] = CacheEntry(
+                base_size_bytes,
+                n_params,
+                meta_model._model.config,
+                meta_model.revision,
             )
 
-            return self.cache[model_key].size_in_bytes
+            logger.info(f"=> New model evaluated: {model_key} base_size: {base_size_bytes}")
 
-        try:
-            meta_model = RemoteableMixin.from_model_key(
-                model_key,
-                dispatch=False,
-                torch_dtype=torch.bfloat16,
-            )
+        entry = self.cache[model_key]
+        padded_size = entry.base_size_in_bytes + entry.base_size_in_bytes * effective_padding
 
-        except Exception as exception:
-            return exception
+        logger.info(f"=> Model {model_key} size: {padded_size} (padding_factor: {effective_padding})")
 
-        param_size = 0
-        n_params = 0
-        for param in meta_model._model.parameters():
-            param_size += param.nelement() * param.element_size()
-            n_params += param.nelement()
-        buffer_size = 0
-        for buffer in meta_model._model.buffers():
-            buffer_size += buffer.nelement() * buffer.element_size()
-
-        model_size_bytes = param_size + buffer_size
-
-        model_size_bytes += model_size_bytes * self.padding_factor
-
-        self.cache[model_key] = CacheEntry(
-            model_size_bytes,
-            n_params,
-            meta_model._model.config,
-            meta_model.revision,
-        )
-
-        logger.info(f"=> New model evaluated: {model_key} size: {model_size_bytes}")
-
-        return model_size_bytes
+        return padded_size

--- a/src/services/ray/src/ray/deployments/controller/cluster/node.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/node.py
@@ -114,6 +114,7 @@ class Node:
         size_bytes: int,
         dedicated: Optional[bool] = None,
         exclude: Optional[Set[MODEL_KEY]] = None,
+        execution_timeout_seconds: Optional[float] = None,
     ):
         # Evict the models from GPU that are needed to deploy the new model
         for eviction in candidate.evictions:
@@ -126,6 +127,7 @@ class Node:
             size_bytes=size_bytes,
             dedicated=dedicated,
             node_id=self.id,
+            execution_timeout_seconds=execution_timeout_seconds,
         )
 
         if model_key in self.cache:

--- a/src/services/ray/src/ray/deployments/controller/controller.py
+++ b/src/services/ray/src/ray/deployments/controller/controller.py
@@ -4,7 +4,7 @@ import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from importlib.metadata import distributions, packages_distributions
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import ray
 from pydantic import BaseModel
@@ -14,6 +14,7 @@ from ....logging.logger import set_logger
 from ....providers.mailgun import MailgunProvider
 from ....providers.objectstore import ObjectStoreProvider
 from ....providers.socketio import SioProvider
+from ....schema.deployment_config import DeploymentConfig
 from ....types import MODEL_KEY
 from ..modeling.base import BaseModelDeploymentArgs
 from ..modeling.util import get_downloaded_models
@@ -33,16 +34,18 @@ class _ControllerActor:
         self,
         deployments: List[MODEL_KEY],
         model_import_path: str,
-        execution_timeout_seconds: float,
+        default_execution_timeout_seconds: float,
         model_cache_percentage: float,
         minimum_deployment_time_seconds: float,
+        default_padding_factor: float,
     ):
         super().__init__()
 
         self.model_import_path = model_import_path
-        self.execution_timeout_seconds = execution_timeout_seconds
+        self.default_execution_timeout_seconds = default_execution_timeout_seconds
         self.minimum_deployment_time_seconds = minimum_deployment_time_seconds
         self.model_cache_percentage = model_cache_percentage
+        self.default_padding_factor = default_padding_factor
         self.runtime_context = ray.get_runtime_context()
         self.logger = set_logger("Controller")
 
@@ -51,12 +54,13 @@ class _ControllerActor:
         self.cluster = Cluster(
             minimum_deployment_time_seconds=self.minimum_deployment_time_seconds,
             model_cache_percentage=self.model_cache_percentage,
+            default_padding_factor=self.default_padding_factor,
         )
 
         self.cluster.update_nodes()
 
         if deployments and deployments != [""]:
-            self._deploy(deployments, dedicated=True)
+            self._deploy({key: DeploymentConfig(dedicated=True) for key in deployments})
 
         asyncio.create_task(self.check_nodes())
 
@@ -65,9 +69,10 @@ class _ControllerActor:
 
         state = {
             "cluster": self.cluster.get_state(include_ray_state=include_ray_state),
-            "execution_timeout_seconds": self.execution_timeout_seconds,
+            "default_execution_timeout_seconds": self.default_execution_timeout_seconds,
             "model_cache_percentage": self.model_cache_percentage,
             "minimum_deployment_time_seconds": self.minimum_deployment_time_seconds,
+            "default_padding_factor": self.default_padding_factor,
         }
 
         if include_ray_state:
@@ -86,20 +91,20 @@ class _ControllerActor:
                 int(os.environ.get("NDIF_CONTROLLER_SYNC_INTERVAL_S", "30"))
             )
 
-    def _deploy(self, model_keys: List[MODEL_KEY], dedicated: Optional[bool] = False):
-        self.logger.info(f"Deploying models: {model_keys}, dedicated: {dedicated}")
+    def _deploy(self, deployments: Union[MODEL_KEY, List[MODEL_KEY], Dict[MODEL_KEY, DeploymentConfig]]):
+        configs = DeploymentConfig.normalize(deployments)
 
-        results, change = self.cluster.deploy(model_keys, dedicated=dedicated)
+        self.logger.info(f"Deploying models: {[(key, cfg.dedicated) for key, cfg in configs.items()]}")
+
+        results, change = self.cluster.deploy(configs)
 
         if change:
             self.apply()
 
         return results
 
-    async def deploy(
-        self, model_keys: List[MODEL_KEY], dedicated: Optional[bool] = False
-    ):
-        return self._deploy(model_keys, dedicated=dedicated)
+    async def deploy(self, deployments: Union[MODEL_KEY, List[MODEL_KEY], Dict[MODEL_KEY, DeploymentConfig]]):
+        return self._deploy(deployments)
 
     def evict(self, model_keys: List[MODEL_KEY]):
         """Evict models from the cluster."""
@@ -222,9 +227,10 @@ class _ControllerActor:
 
         # Create models from disk - spawn monitoring tasks
         for name, deployment in deployment_delta.deployments_to_create:
+            execution_timeout = deployment.execution_timeout_seconds if deployment.execution_timeout_seconds is not None else self.default_execution_timeout_seconds
             deployment_args = BaseModelDeploymentArgs(
                 model_key=deployment.model_key,
-                execution_timeout=self.execution_timeout_seconds,
+                execution_timeout=execution_timeout,
             )
 
             # create() returns None always, but may fail internally
@@ -476,14 +482,17 @@ class ControllerDeploymentArgs(BaseModel):
     deployments: List[MODEL_KEY] = os.environ.get("NDIF_DEPLOYMENTS", "").split("|")
 
     model_import_path: str = "src.ray.deployments.modeling.model:app"
-    execution_timeout_seconds: Optional[float] = float(
-        os.environ.get("NDIF_EXECUTION_TIMEOUT_SECONDS", "3600")
+    default_execution_timeout_seconds: Optional[float] = float(
+        os.environ.get("NDIF_DEFAULT_EXECUTION_TIMEOUT_SECONDS", "3600")
     )
     minimum_deployment_time_seconds: Optional[float] = float(
         os.environ.get("NDIF_MINIMUM_DEPLOYMENT_TIME_SECONDS", "3600")
     )
     model_cache_percentage: Optional[float] = float(
         os.environ.get("NDIF_MODEL_CACHE_PERCENTAGE", "0.9")
+    )
+    default_padding_factor: Optional[float] = float(
+        os.environ.get("NDIF_DEFAULT_PADDING_FACTOR", "0.15")
     )
 
 

--- a/src/services/ray/src/ray/deployments/controller/gcal/scheduler.py
+++ b/src/services/ray/src/ray/deployments/controller/gcal/scheduler.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 import ray
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
+from .....schema.deployment_config import DeploymentConfig
 from .....types import MODEL_KEY
 from .....providers.mailgun import MailgunProvider
 from ..cluster.node import CandidateLevel
@@ -139,8 +140,9 @@ class SchedulingActor:
                 "Change in model deployment state. Sending deployment request to Controller..."
             )
             # Update the controller with new model keys
+            configs = {key: DeploymentConfig(dedicated=True) for key in model_keys_to_event.keys()}
             result: Dict[str, str] = await self.controller_handle.deploy.remote(
-                list(model_keys_to_event.keys()), dedicated=True
+                configs
             )
             result = result["result"]
             error_messages = {


### PR DESCRIPTION
## Summary
- Introduces `DeploymentConfig` pydantic model (`src/common/schema/deployment_config.py`) with `dedicated`, `padding_factor`, and `execution_timeout_seconds` fields
- `deploy()` now accepts a string, list of strings, or `Dict[MODEL_KEY, DeploymentConfig]` — normalized via `DeploymentConfig.normalize()`
- Server-wide defaults controlled via `NDIF_DEFAULT_EXECUTION_TIMEOUT_SECONDS` and `NDIF_DEFAULT_PADDING_FACTOR` env vars, with per-deployment overrides taking precedence
- Model evaluator caches base size (without padding) and applies padding factor at call time

## Test plan
- [ ] Verify deploy with a single model key string still works
- [ ] Verify deploy with a list of model key strings still works
- [ ] Verify deploy with a dict of model key -> DeploymentConfig works
- [ ] Verify custom padding_factor override produces different GPU allocation
- [ ] Verify custom execution_timeout_seconds is used by ModelActor
- [ ] Verify CLI `ndif deploy` works with --dedicated flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)