### PR TITLE
Refactor Resources into GPU, GPUResources, and CPUResources

### DIFF
--- a/src/services/ray/src/ray/deployments/controller/cluster/cluster.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/cluster.py
@@ -11,7 +11,7 @@ from ray.util.state import list_nodes
 
 from .....types import MODEL_KEY, NODE_ID
 from .evaluator import ModelEvaluator
-from .node import CandidateLevel, Node, Resources
+from .node import CandidateLevel, CPUResources, GPU, GPUResources, Node
 
 logger = logging.getLogger("ndif")
 
@@ -77,10 +77,9 @@ class Cluster:
             current_nodes.add(id)
 
             if id not in self.nodes:
-                total_gpus = node.resources_total["GPU"]
-                gpu_type = "TEST"
-                # gpu_type = node.resources_total["GPU_TYPE"]
-                gpu_memory_bytes = (
+                total_gpus = int(node.resources_total["GPU"])
+                gpu_type = node.labels.get("ray.io/accelerator-type", "unknown")
+                per_gpu_memory_bytes = (
                     (node.resources_total["cuda_memory_bytes"]) / total_gpus
                 )
                 cpu_memory_bytes = (
@@ -88,22 +87,32 @@ class Cluster:
                     * self.model_cache_percentage
                 )
 
+                gpus = [
+                    GPU(index=i, memory_bytes=per_gpu_memory_bytes)
+                    for i in range(total_gpus)
+                ]
+
+                gpu_resources = GPUResources(
+                    gpu_type=gpu_type,
+                    gpus=gpus,
+                    available=list(range(total_gpus)),
+                )
+
+                cpu_resources = CPUResources(
+                    memory_bytes=cpu_memory_bytes,
+                    available_memory_bytes=cpu_memory_bytes,
+                )
+
                 self.nodes[id] = Node(
                     id,
                     name,
-                    Resources(
-                        total_gpus=total_gpus,
-                        gpu_type=gpu_type,
-                        gpu_memory_bytes=gpu_memory_bytes,
-                        cpu_memory_bytes=cpu_memory_bytes,
-                        available_cpu_memory_bytes=cpu_memory_bytes,
-                        available_gpus=list(range(int(total_gpus))),
-                    ),
+                    gpu_resources=gpu_resources,
+                    cpu_resources=cpu_resources,
                     minimum_deployment_time_seconds=self.minimum_deployment_time_seconds,
                 )
 
             logger.info(
-                f"=> Node {name} updated with resources: {self.nodes[id].resources}"
+                f"=> Node {name} updated with gpu_resources: {self.nodes[id].gpu_resources}, cpu_resources: {self.nodes[id].cpu_resources}"
             )
 
         for node_id in self.nodes.keys():

--- a/src/services/ray/src/ray/deployments/controller/cluster/node.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/node.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any, Dict, List, Optional, Set
 
@@ -32,46 +32,55 @@ class Candidate:
 
 
 @dataclass
-class Resources:
-    total_gpus: int
+class GPU:
+    index: int
+    memory_bytes: int
 
+
+@dataclass
+class GPUResources:
     gpu_type: str
+    gpus: list[GPU]
+    available: list[int]
 
-    gpu_memory_bytes: int
-    cpu_memory_bytes: int
+    @property
+    def total(self) -> int:
+        return len(self.gpus)
 
-    available_cpu_memory_bytes: int
-    available_gpus: list[int]
+    @property
+    def memory_bytes(self) -> int:
+        return self.gpus[0].memory_bytes if self.gpus else 0
 
-    def gpus_required(self, model_size_in_bytes: int) -> int:
-        if self.gpu_memory_bytes == 0:
+    def required(self, model_size_in_bytes: int) -> int:
+        if self.memory_bytes == 0:
             raise ValueError("GPU memory bytes is 0")
 
-        return int(model_size_in_bytes // self.gpu_memory_bytes + 1)
+        return int(model_size_in_bytes // self.memory_bytes + 1)
 
-    def assign(self, gpus_required: int) -> list[int]:
-        if gpus_required > len(self.available_gpus):
+    def assign(self, count: int) -> list[int]:
+        if count > len(self.available):
             raise ValueError(
-                f"Not enough GPUs available to assign {gpus_required} GPUs"
+                f"Not enough GPUs available to assign {count} GPUs"
             )
 
-        gpus = self.available_gpus[:gpus_required]
-
-        self.available_gpus = self.available_gpus[gpus_required:]
-
+        gpus = self.available[:count]
+        self.available = self.available[count:]
         return gpus
 
-    def __str__(self):
-        return (
-            f"Resources("
-            f"total_gpus={self.total_gpus}, "
-            f"gpu_type={self.gpu_type}, "
-            f"gpu_memory_bytes={self.gpu_memory_bytes}, "
-            f"cpu_memory_bytes={self.cpu_memory_bytes}, "
-            f"available_cpu_memory_bytes={self.available_cpu_memory_bytes}, "
-            f"available_gpus={self.available_gpus}, "
-            f")"
-        )
+    def release(self, indices: list[int]) -> None:
+        self.available.extend(indices)
+
+
+@dataclass
+class CPUResources:
+    memory_bytes: int
+    available_memory_bytes: int
+
+    def allocate(self, size_bytes: int) -> None:
+        self.available_memory_bytes -= size_bytes
+
+    def release(self, size_bytes: int) -> None:
+        self.available_memory_bytes += size_bytes
 
 
 class Node:
@@ -79,12 +88,14 @@ class Node:
         self,
         id: NODE_ID,
         name: str,
-        resources: Resources,
+        gpu_resources: GPUResources,
+        cpu_resources: CPUResources,
         minimum_deployment_time_seconds: float = None,
     ):
         self.id = id
         self.name = name
-        self.resources = resources
+        self.gpu_resources = gpu_resources
+        self.cpu_resources = cpu_resources
         self.minimum_deployment_time_seconds = minimum_deployment_time_seconds
 
         self.deployments: Dict[MODEL_KEY, Deployment] = {}
@@ -96,7 +107,14 @@ class Node:
         return {
             "id": self.id,
             "name": self.name,
-            "resources": asdict(self.resources),
+            "resources": {
+                "gpu_type": self.gpu_resources.gpu_type,
+                "total_gpus": self.gpu_resources.total,
+                "gpu_memory_bytes": self.gpu_resources.memory_bytes,
+                "available_gpus": self.gpu_resources.available,
+                "cpu_memory_bytes": self.cpu_resources.memory_bytes,
+                "available_cpu_memory_bytes": self.cpu_resources.available_memory_bytes,
+            },
             "deployments": [
                 deployment.get_state() for deployment in self.deployments.values()
             ],
@@ -122,7 +140,7 @@ class Node:
         self.deployments[model_key] = Deployment(
             model_key=model_key,
             deployment_level=DeploymentLevel.HOT,
-            gpus=self.resources.assign(candidate.gpus_required),
+            gpus=self.gpu_resources.assign(candidate.gpus_required),
             size_bytes=size_bytes,
             dedicated=dedicated,
         )
@@ -131,19 +149,19 @@ class Node:
             del self.cache[model_key]
 
             # Return its cpu memory to the node
-            self.resources.available_cpu_memory_bytes += size_bytes
+            self.cpu_resources.release(size_bytes)
 
     def evict(self, model_key: MODEL_KEY, exclude: Optional[Set[MODEL_KEY]] = None):
         deployment = self.deployments[model_key]
 
-        self.resources.available_gpus.extend(deployment.gpus)
+        self.gpu_resources.release(deployment.gpus)
 
         cpu_memory_needed = (
-            deployment.size_bytes - self.resources.available_cpu_memory_bytes
+            deployment.size_bytes - self.cpu_resources.available_memory_bytes
         )
 
         logger.info(
-            f"Evicting {model_key} from {self.name} with cpu memory needed: {cpu_memory_needed} = {deployment.size_bytes} - {self.resources.available_cpu_memory_bytes}"
+            f"Evicting {model_key} from {self.name} with cpu memory needed: {cpu_memory_needed} = {deployment.size_bytes} - {self.cpu_resources.available_memory_bytes}"
         )
 
         if cpu_memory_needed > 0:
@@ -170,14 +188,12 @@ class Node:
 
                     del self.cache[eviction_deployment.model_key]
 
-                    self.resources.available_cpu_memory_bytes += (
-                        eviction_deployment.size_bytes
-                    )
+                    self.cpu_resources.release(eviction_deployment.size_bytes)
 
         del self.deployments[model_key]
 
         if cpu_memory_needed <= 0:
-            self.resources.available_cpu_memory_bytes -= deployment.size_bytes
+            self.cpu_resources.allocate(deployment.size_bytes)
 
             self.cache[model_key] = Deployment(
                 model_key=deployment.model_key,
@@ -190,7 +206,7 @@ class Node:
     def evictions(self, gpus_required: int, dedicated: bool = False) -> List[MODEL_KEY]:
         deployments = sorted(list(self.deployments.values()), key=lambda x: len(x.gpus))
 
-        gpus_needed = gpus_required - len(self.resources.available_gpus)
+        gpus_needed = gpus_required - len(self.gpu_resources.available)
 
         evictions = []
 
@@ -226,9 +242,9 @@ class Node:
 
         cached = model_key in self.cache
 
-        gpus_required = self.resources.gpus_required(model_size_in_bytes)
+        gpus_required = self.gpu_resources.required(model_size_in_bytes)
 
-        if gpus_required <= len(self.resources.available_gpus):
+        if gpus_required <= len(self.gpu_resources.available):
             return Candidate(
                 candidate_level=(
                     CandidateLevel.CACHED_AND_FREE if cached else CandidateLevel.FREE
@@ -236,7 +252,7 @@ class Node:
                 gpus_required=gpus_required,
             )
 
-        elif gpus_required <= self.resources.total_gpus:
+        elif gpus_required <= self.gpu_resources.total:
             candidate = Candidate(
                 candidate_level=(
                     CandidateLevel.CACHED_AND_FULL if cached else CandidateLevel.FULL

--- a/src/services/ray/src/ray/deployments/controller/controller.py
+++ b/src/services/ray/src/ray/deployments/controller/controller.py
@@ -303,9 +303,9 @@ class _ControllerActor:
                 "nodes": {
                     node_id: {
                         "resources": {
-                            "total_gpus": node.resources.total_gpus,
-                            "gpu_memory_bytes": node.resources.gpu_memory_bytes,
-                            "available_gpus": node.resources.available_gpus,
+                            "total_gpus": node.gpu_resources.total,
+                            "gpu_memory_bytes": node.gpu_resources.memory_bytes,
+                            "available_gpus": node.gpu_resources.available,
                         },
                         "deployments": {
                             model_key: {


### PR DESCRIPTION
## Summary
- Split monolithic `Resources` dataclass into `GPU`, `GPUResources`, and `CPUResources` for clearer separation of GPU and CPU resource management
- Added `assign`/`release` methods on `GPUResources` and `allocate`/`release` on `CPUResources` to encapsulate resource mutation
- Pull `gpu_type` from Ray node labels (`ray.io/accelerator-type`) instead of hardcoding

## Test plan
- [ ] Verify controller deploys and evicts models correctly with the new resource classes
- [ ] Verify `get_state()` and `status()` return the same shape as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)