### PR TITLE
Configurable actor_class for model deployments

### DIFF
--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -18,9 +18,12 @@ from ..lib.model_config import load_model_config
 @click.option('--sync', is_flag=True, help='Sync mode: evict models not in config file (requires -f)')
 @click.option('--revision', default=None, help='Model revision/branch (default: model\'s default)')
 @click.option('--dedicated', is_flag=True, help='Deploy as dedicated - will not be evicted (default: False)')
+@click.option('--actor-class', 'actor_class', default=None,
+              help='Dotted import path of the Ray actor class to use (default: ModelActor). '
+                   'With -f, acts as the default for entries that do not set actor_class themselves.')
 @click.option('--ray-address', default=None, help='Ray address (default: from NDIF_RAY_ADDRESS)')
 @click.option('--broker-url', default=None, help='Broker URL (default: from NDIF_BROKER_URL)')
-def deploy(checkpoints: tuple, config_file: str, sync: bool, revision: str, dedicated: bool, ray_address: str, broker_url: str):
+def deploy(checkpoints: tuple, config_file: str, sync: bool, revision: str, dedicated: bool, actor_class: str, ray_address: str, broker_url: str):
     """Deploy one or more models without requiring to submit a request.
 
     CHECKPOINTS: One or more model checkpoints (e.g., "gpt2", "meta-llama/Llama-2-7b-hf")
@@ -62,13 +65,14 @@ def deploy(checkpoints: tuple, config_file: str, sync: bool, revision: str, dedi
                     Path(config_file),
                     default_revision=revision,
                     default_dedicated=dedicated,
+                    default_actor_class=actor_class,
                 )
             except (FileNotFoundError, ValueError) as e:
                 raise click.ClickException(str(e))
             click.echo(f"Loaded {len(model_specs)} model(s) from {config_file}")
         else:
             model_specs = [
-                {"checkpoint": cp, "revision": revision, "dedicated": dedicated}
+                {"checkpoint": cp, "revision": revision, "dedicated": dedicated, "actor_class": actor_class}
                 for cp in checkpoints
             ]
 
@@ -103,7 +107,13 @@ def deploy(checkpoints: tuple, config_file: str, sync: bool, revision: str, dedi
             dedicated_label = " (dedicated)" if is_dedicated else ""
             click.echo(f"\nDeploying {len(batch_keys)} model(s){dedicated_label}...")
 
-            configs = {k: DeploymentConfig(dedicated=is_dedicated) for k in batch_keys}
+            configs = {
+                k: DeploymentConfig(
+                    dedicated=is_dedicated,
+                    actor_class=model_keys_map[k].get("actor_class"),
+                )
+                for k in batch_keys
+            }
             object_ref = controller._deploy.remote(deployments=configs)
             results = ray.get(object_ref)
 

--- a/cli/commands/export.py
+++ b/cli/commands/export.py
@@ -89,8 +89,9 @@ def _build_models_list(deployments: list[dict]) -> list:
         repo_id = dep.get("repo_id") or dep.get("checkpoint")
         revision = dep.get("revision")
         dedicated = dep.get("dedicated", False)
+        actor_class = dep.get("actor_class")
 
-        if not revision and not dedicated:
+        if not revision and not dedicated and not actor_class:
             models.append(repo_id)
         else:
             entry = {"checkpoint": repo_id}
@@ -98,5 +99,7 @@ def _build_models_list(deployments: list[dict]) -> list:
                 entry["revision"] = revision
             if dedicated:
                 entry["dedicated"] = dedicated
+            if actor_class:
+                entry["actor_class"] = actor_class
             models.append(entry)
     return models

--- a/cli/lib/model_config.py
+++ b/cli/lib/model_config.py
@@ -8,6 +8,7 @@ File format:
       - checkpoint: meta-llama/Llama-3.1-8b     # Full: with options
         dedicated: true
         revision: main
+        actor_class: ray.deployments.modeling.base.ModelActor  # optional
 """
 
 from pathlib import Path
@@ -31,6 +32,7 @@ MODELS_YAML_TEMPLATE = """\
 #     - checkpoint: meta-llama/Llama-3.1-8b
 #       revision: main                    # Optional: specific revision/branch
 #       dedicated: true                   # Optional: won't be evicted (default: false)
+#       actor_class: ray.deployments.modeling.base.ModelActor  # Optional: custom Ray actor class
 #
 # Commands:
 #   ndif deploy -f models.yaml            # Deploy models from this file
@@ -61,6 +63,7 @@ def load_model_config(
     file_path: Path,
     default_revision: Optional[str] = None,
     default_dedicated: bool = False,
+    default_actor_class: Optional[str] = None,
 ) -> list[dict]:
     """Load model specifications from a YAML config file.
 
@@ -68,9 +71,11 @@ def load_model_config(
         file_path: Path to the YAML config file
         default_revision: Default revision to use when not specified in file
         default_dedicated: Default dedicated flag to use when not specified in file
+        default_actor_class: Default Ray actor class (dotted import path) to use
+            when not specified in file
 
     Returns:
-        List of model spec dicts with checkpoint, revision, dedicated keys
+        List of model spec dicts with checkpoint, revision, dedicated, actor_class keys
 
     Raises:
         FileNotFoundError: If file doesn't exist
@@ -97,15 +102,17 @@ def load_model_config(
                 "checkpoint": item,
                 "revision": default_revision,
                 "dedicated": default_dedicated,
+                "actor_class": default_actor_class,
             })
         elif isinstance(item, dict):
-            # Full form: dict with checkpoint and optional revision/dedicated
+            # Full form: dict with checkpoint and optional revision/dedicated/actor_class
             if "checkpoint" not in item:
                 raise ValueError(f"Model entry missing 'checkpoint': {item}")
             specs.append({
                 "checkpoint": item["checkpoint"],
                 "revision": item.get("revision", default_revision),
                 "dedicated": item.get("dedicated", default_dedicated),
+                "actor_class": item.get("actor_class", default_actor_class),
             })
         else:
             raise ValueError(f"Invalid model entry (must be string or dict): {item}")
@@ -129,9 +136,10 @@ def save_model_config(file_path: Path, deployments: list[dict]):
         repo_id = dep.get("repo_id") or dep.get("checkpoint")
         revision = dep.get("revision")
         dedicated = dep.get("dedicated", False)
+        actor_class = dep.get("actor_class")
 
         # Use simple form if no special options
-        if not revision and not dedicated:
+        if not revision and not dedicated and not actor_class:
             models.append(repo_id)
         else:
             entry = {"checkpoint": repo_id}
@@ -139,6 +147,8 @@ def save_model_config(file_path: Path, deployments: list[dict]):
                 entry["revision"] = revision
             if dedicated:
                 entry["dedicated"] = dedicated
+            if actor_class:
+                entry["actor_class"] = actor_class
             models.append(entry)
 
     config = {"models": models}

--- a/src/common/schema/deployment_config.py
+++ b/src/common/schema/deployment_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from ..types import MODEL_KEY
 
@@ -10,9 +10,23 @@ from ..types import MODEL_KEY
 class DeploymentConfig(BaseModel):
     """Configuration for a model deployment."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     dedicated: bool = False
     padding_factor: Optional[float] = None
     execution_timeout_seconds: Optional[float] = None
+    actor_class: Optional[Union[str, type]] = None
+    """Ray actor class used to serve this deployment.
+
+    Accepts either a dotted import path (e.g. ``"ray.deployments.modeling.base.ModelActor"``)
+    resolvable inside the Ray actor's Python path, or a class object already
+    decorated with ``@ray.remote``. ``None`` uses the default ``ModelActor``.
+
+    A user-supplied class must already be ``@ray.remote``-decorated — it will
+    be called as ``actor_class.options(...).remote(...)``; we do not wrap it,
+    so any ``num_cpus`` / ``num_gpus`` / ``max_restarts`` on the decorator are
+    preserved as-is.
+    """
 
     @staticmethod
     def normalize(

--- a/src/services/ray/src/ray/deployments/controller/cluster/cluster.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/cluster.py
@@ -265,6 +265,7 @@ class Cluster:
                         dedicated=dedicated,
                         exclude=all_model_keys,
                         execution_timeout_seconds=config.execution_timeout_seconds,
+                        actor_class=config.actor_class,
                     )
 
                     results["evictions"].update(candidate.evictions)

--- a/src/services/ray/src/ray/deployments/controller/cluster/deployment.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/deployment.py
@@ -1,8 +1,9 @@
+import importlib
 import logging
 import time
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Union
 
 import ray
 from opentelemetry import trace
@@ -12,7 +13,7 @@ from .....providers.objectstore import ObjectStoreProvider
 from .....providers.socketio import SioProvider
 from .....tracing import TracingContext, trace_span
 from .....types import MODEL_KEY
-from ...modeling.base import BaseModelDeploymentArgs, ModelActor
+from ...modeling.base import BaseModelDeployment, BaseModelDeploymentArgs, ModelActor
 
 logger = logging.getLogger("ndif")
 
@@ -33,6 +34,7 @@ class Deployment:
         dedicated: bool = False,
         node_id: str = None,
         execution_timeout_seconds: float | None = None,
+        actor_class: Optional[Union[str, type]] = None,
     ):
         self.model_key = model_key
         self.deployment_level = deployment_level
@@ -41,7 +43,26 @@ class Deployment:
         self.dedicated = dedicated
         self.node_id = node_id
         self.execution_timeout_seconds = execution_timeout_seconds
+        self.actor_class = actor_class
         self.deployed = time.time()
+
+    def _resolve_actor_class(self) -> type[BaseModelDeployment]:
+        """Resolve ``self.actor_class`` to a concrete Ray actor class.
+
+        Strings are imported as dotted paths. ``None`` falls back to the
+        default ``ModelActor``. Class objects are returned as-is.
+        """
+        if self.actor_class is None:
+            return ModelActor
+        if isinstance(self.actor_class, str):
+            module_path, _, class_name = self.actor_class.rpartition(".")
+            if not module_path:
+                raise ValueError(
+                    f"actor_class {self.actor_class!r} is not a dotted import path"
+                )
+            module = importlib.import_module(module_path)
+            return getattr(module, class_name)
+        return self.actor_class
 
     @property
     def name(self):
@@ -54,6 +75,15 @@ class Deployment:
     def get_state(self) -> Dict[str, Any]:
         """Get the state of the deployment."""
 
+        if self.actor_class is None:
+            actor_class_repr = None
+        elif isinstance(self.actor_class, str):
+            actor_class_repr = self.actor_class
+        else:
+            actor_class_repr = (
+                f"{self.actor_class.__module__}.{self.actor_class.__qualname__}"
+            )
+
         return {
             "model_key": self.model_key,
             "deployment_level": self.deployment_level.value,
@@ -62,6 +92,7 @@ class Deployment:
             "dedicated": self.dedicated,
             "node_id": self.node_id,
             "execution_timeout_seconds": self.execution_timeout_seconds,
+            "actor_class": actor_class_repr,
             "deployed": self.deployed,
         }
 
@@ -71,7 +102,9 @@ class Deployment:
         )
 
     def delete(self):
-        with trace_span("deployment.delete", attributes={"ndif.model.key": self.model_key}) as span:
+        with trace_span(
+            "deployment.delete", attributes={"ndif.model.key": self.model_key}
+        ) as span:
             try:
                 actor = self.actor
                 ray.kill(actor, no_restart=True)
@@ -81,7 +114,9 @@ class Deployment:
                 pass
 
     def restart(self):
-        with trace_span("deployment.restart", attributes={"ndif.model.key": self.model_key}) as span:
+        with trace_span(
+            "deployment.restart", attributes={"ndif.model.key": self.model_key}
+        ) as span:
             try:
                 actor = self.actor
                 ray.kill(actor, no_restart=False)
@@ -91,7 +126,9 @@ class Deployment:
                 pass
 
     def cache(self):
-        with trace_span("deployment.cache", attributes={"ndif.model.key": self.model_key}) as span:
+        with trace_span(
+            "deployment.cache", attributes={"ndif.model.key": self.model_key}
+        ) as span:
             try:
                 actor = self.actor
                 return actor.to_cache.remote(TracingContext.inject())
@@ -101,10 +138,13 @@ class Deployment:
                 return None
 
     def from_cache(self):
-        with trace_span("deployment.from_cache", attributes={
-            "ndif.model.key": self.model_key,
-            "ndif.deploy.gpus": str(self.gpus),
-        }) as span:
+        with trace_span(
+            "deployment.from_cache",
+            attributes={
+                "ndif.model.key": self.model_key,
+                "ndif.deploy.gpus": str(self.gpus),
+            },
+        ) as span:
             try:
                 actor = self.actor
                 return actor.from_cache.remote(self.gpus, TracingContext.inject())
@@ -114,11 +154,14 @@ class Deployment:
                 return None
 
     def create(self, node_name: str, deployment_args: BaseModelDeploymentArgs):
-        with trace_span("deployment.create", attributes={
-            "ndif.model.key": self.model_key,
-            "ndif.deploy.node": node_name,
-            "ndif.deploy.gpus": str(self.gpus),
-        }) as span:
+        with trace_span(
+            "deployment.create",
+            attributes={
+                "ndif.model.key": self.model_key,
+                "ndif.deploy.node": node_name,
+                "ndif.deploy.gpus": str(self.gpus),
+            },
+        ) as span:
             try:
                 # Inject the assigned GPU memory allocation so the actor knows which GPUs to target
                 deployment_args.gpu_mem_bytes_by_id = self.gpus
@@ -138,7 +181,9 @@ class Deployment:
 
                 env_vars = {k: v for k, v in env_vars.items() if v is not None}
 
-                actor = ModelActor.options(
+                actor_class = self._resolve_actor_class()
+
+                actor = actor_class.options(
                     name=self.name,
                     resources={f"node:{node_name}": 0.01},
                     namespace="NDIF",

--- a/src/services/ray/src/ray/deployments/controller/cluster/node.py
+++ b/src/services/ray/src/ray/deployments/controller/cluster/node.py
@@ -3,7 +3,7 @@ import math
 import time
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Union
 
 from .....types import MODEL_KEY, NODE_ID
 from .deployment import Deployment, DeploymentLevel
@@ -162,6 +162,7 @@ class Node:
         dedicated: Optional[bool] = None,
         exclude: Optional[Set[MODEL_KEY]] = None,
         execution_timeout_seconds: Optional[float] = None,
+        actor_class: Optional[Union[str, type]] = None,
     ):
         # Evict the models from GPU that are needed to deploy the new model
         for eviction in candidate.evictions:
@@ -177,6 +178,7 @@ class Node:
             dedicated=dedicated,
             node_id=self.id,
             execution_timeout_seconds=execution_timeout_seconds,
+            actor_class=actor_class,
         )
 
         if model_key in self.cache:
@@ -245,6 +247,7 @@ class Node:
                 size_bytes=deployment.size_bytes,
                 dedicated=False,
                 node_id=self.id,
+                actor_class=deployment.actor_class,
             )
 
     def evictable(self, deployment: Deployment, dedicated: bool) -> bool:


### PR DESCRIPTION
## Summary
- Adds optional `actor_class` field to `DeploymentConfig` (accepts a dotted import path or a `@ray.remote` class object; defaults to `ModelActor`).
- Threads it through `Cluster.deploy` → `Node.deploy` → `Deployment`, resolved at `Deployment.create()` time. WARM-cache Deployments carry it forward on eviction so `get_state()` stays consistent.
- CLI: `ndif deploy --actor-class <path>`; `-f <yaml>` supports a per-entry `actor_class` field, with `--actor-class` acting as the default for entries that omit it. `ndif export` round-trips the field into YAML.

## Usage
YAML:
```yaml
models:
  - gpt2                                    # default ModelActor
  - checkpoint: meta-llama/Llama-3.1-8B
    dedicated: true
    actor_class: ray.deployments.modeling.base.MyModelActor
```

CLI:
```
ndif deploy gpt2 --actor-class ray.deployments.modeling.base.MyModelActor
```

## Notes
- User-supplied classes must already be `@ray.remote`-decorated; we do not wrap them, so any `num_cpus`/`num_gpus`/`max_restarts` on the decorator are preserved.
- The Ray actor name (`ModelActor:<model_key>`) is a registry key and is intentionally unchanged even for custom classes, so `restart()` / lookup paths keep working.

## Test plan
- [ ] `make ta` and run `scripts/test.py` — default path (no `actor_class`) behaves identically.
- [ ] `ndif deploy gpt2 --actor-class ray.deployments.modeling.base.ModelActor` deploys successfully.
- [ ] YAML with a per-entry `actor_class` deploys that entry with the named class.
- [ ] `ndif export -f out.yaml` + `ndif deploy -f out.yaml` is stable for deployments created with a custom `actor_class`.
- [ ] Bad dotted path surfaces a clear `ImportError`/`AttributeError` in the controller logs.