### PR TITLE
fix(socketio): serialize async reconnect so concurrent emits can't cancel each other's connect

### DIFF
--- a/src/ndif/common/providers/__init__.py
+++ b/src/ndif/common/providers/__init__.py
@@ -121,7 +121,9 @@ def async_retry(fn: Callable) -> Callable:
         for attempt in range(cls.max_retries):
             try:
                 if not cls.async_connected() and fn.__name__ != "async_connect":
-                    await cls.async_reset()
+                    # async_connect() owns the connection lifecycle (reset +
+                    # rebuild + connect) under its lock, so concurrent callers
+                    # serialize on it and share a single client.
                     await cls.async_connect()
                 return await fn(cls, *args, **kwargs)
             except Exception as e:

--- a/src/ndif/common/providers/socketio.py
+++ b/src/ndif/common/providers/socketio.py
@@ -124,9 +124,14 @@ class SioProvider(Provider):
             if cls.async_connected():
                 return
 
-            if cls._async_sio is None:
-                logger.debug("Creating new async socketio client")
-                cls._async_sio = socketio.AsyncSimpleClient(reconnection_attempts=10)
+            # Own the full connection lifecycle here, under the lock: drop any
+            # existing client, build a fresh one, and connect. Keeping reset and
+            # connect together under the lock means one task rebuilds the
+            # connection while concurrent callers wait and then reuse it.
+            await cls.async_reset()
+
+            logger.debug("Creating new async socketio client")
+            cls._async_sio = socketio.AsyncSimpleClient(reconnection_attempts=10)
 
             await cls._async_sio.connect(
                 cls.api_url,

--- a/src/ndif/common/tests/test_socketio_reconnect.py
+++ b/src/ndif/common/tests/test_socketio_reconnect.py
@@ -1,0 +1,100 @@
+"""Concurrent SioProvider reconnects must be serialized.
+
+When several Dispatcher coroutines deliver a status update while the socket.io
+connection is down, they all reach the reconnect path. ``async_connect`` owns
+the connection lifecycle (reset + rebuild + connect) under its lock, so one
+task rebuilds the connection while the others wait and reuse it — every emit
+should complete cleanly.
+
+This test drives that shape directly: N pairs of concurrent ``async_emit``
+against a local socket.io server while disconnected, asserting every emit
+succeeds with no exception. Self-contained — spins up its own socket.io
+server, no live NDIF stack needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from ndif.common.providers.socketio import SioProvider
+
+pytest.importorskip("aiohttp")
+import socketio  # noqa: E402  (hard dep of the module under test)
+from aiohttp import web  # noqa: E402
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+async def _run_concurrent_emits(iterations: int = 10, concurrency: int = 2) -> list:
+    port = _free_port()
+    server = socketio.AsyncServer(async_mode="aiohttp")
+
+    @server.event
+    async def connect(sid, environ):
+        # Widen the handshake window so a concurrent reconnect deterministically
+        # interleaves with an in-flight connect.
+        await asyncio.sleep(0.05)
+
+    @server.event
+    async def blocking_response(sid, *args):
+        return "ok"
+
+    app = web.Application()
+    server.attach(app, socketio_path="/ws/socket.io")
+    runner = web.AppRunner(app)
+    await runner.setup()
+    await web.TCPSite(runner, "127.0.0.1", port).start()
+
+    # Point the provider at the local server. max_retries=1 so a reconnect
+    # failure surfaces instead of being retried into a pass.
+    SioProvider.api_url = f"http://127.0.0.1:{port}"
+    SioProvider.max_retries = 1
+    SioProvider.retry_interval = 0.01
+
+    results: list = []
+    try:
+        for _ in range(iterations):
+            # Fresh, disconnected state — forces every emit through the reconnect path.
+            SioProvider._async_sio = None
+            SioProvider._async_connect_lock = None
+            res = await asyncio.gather(
+                *(
+                    SioProvider.async_emit("blocking_response", data=("sid", b"x"))
+                    for _ in range(concurrency)
+                ),
+                return_exceptions=True,
+            )
+            results.extend(res)
+            try:
+                await SioProvider.async_reset()
+            except Exception:
+                pass
+    finally:
+        try:
+            await SioProvider.async_reset()
+        except Exception:
+            pass
+        await runner.cleanup()
+    return results
+
+
+def test_concurrent_async_emit_does_not_race_on_reconnect():
+    results = asyncio.run(_run_concurrent_emits())
+    failures = [r for r in results if isinstance(r, BaseException)]
+    assert not failures, (
+        f"{len(failures)}/{len(results)} concurrent emits raised "
+        f"{sorted({type(e).__name__ for e in failures})} — reconnect is not serialized"
+    )
+
+
+if __name__ == "__main__":  # allow standalone run without pytest
+    test_concurrent_async_emit_does_not_race_on_reconnect()
+    print("PASS")

--- a/src/ndif/services/ray/start.sh
+++ b/src/ndif/services/ray/start.sh
@@ -19,6 +19,7 @@ if [ -z "$RAY_ADDRESS" ]; then
     ray start --head \
         --resources="$resources" \
         --port=${NDIF_RAY_HEAD_PORT} \
+        --ray-client-server-port=${NDIF_RAY_CLIENT_PORT} \
         --object-manager-port=${NDIF_RAY_OBJECT_MANAGER_PORT} \
         --include-dashboard=true \
         --dashboard-host=0.0.0.0 \


### PR DESCRIPTION
## Problem

Two Dispatcher coroutines delivering a status update while the socket.io connection is down both enter the reconnect path. `async_retry` called `async_reset()` **outside** `async_connect()`'s lock, so the second coroutine's reset disconnected the client the first was mid-`connect()` on. The cancelled in-flight connect raised `asyncio.CancelledError` — a `BaseException` that escaped the dispatch loop's `except Exception` and killed the unsupervised `DispatcherProcess`. Result: the Redis `queue` stops draining, `/status` 504s, and traces hang at `RECEIVED` (cluster-wide wedge), with `ray:connected` left set so it looks healthy.

The fatal form needs concurrency on (re)connect **and** a hostname DNS resolve in the path, so the cancellation lands on aiohttp's shielded `_resolve_host`. On an IP literal the same race surfaces as a benign-looking `ConnectionError`, which is why local testing missed it.

## Fix

Serialize the entire reconnect (check → reset → rebuild → connect) under `async_connect`'s lock:

- `common/providers/socketio.py` — move the teardown (`async_reset`) **inside** `async_connect`'s lock, then rebuild + connect under the same lock. The lock holder is the only task that touches the shared `_async_sio`, so concurrent callers block at the lock and reuse the connection once it's up — no task can disconnect another's in-flight connect.
- `common/providers/__init__.py` — `async_retry` reconnects via `async_connect()` only; the unlocked `async_reset()` call is removed.

## Test

`common/tests/test_socketio_reconnect.py` — fires concurrent `async_emit` pairs against a local socket.io server while disconnected and asserts every emit completes cleanly. Self-contained (no live NDIF stack). Verified: fails on the pre-fix code (the race), passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note
Also passes `--ray-client-server-port=$NDIF_RAY_CLIENT_PORT` in `ray/start.sh` so the Ray client server binds the port the API/dashboard actually dial. Without it Ray always used its default 10001, so any non-default `NDIF_RAY_CLIENT_PORT` left the Ray client connect hanging.
