### PR TITLE
Persistent Object Pre-Loading Inside Runner Process

### DIFF
--- a/docs/concepts/sandbox-execution.md
+++ b/docs/concepts/sandbox-execution.md
@@ -92,16 +92,18 @@ worker asked for something the model already ran past.
 |---|---|
 | the serialized request payload (host → runner, once) | the model, its weights, and its module tree — host only |
 | an activation a worker is actually parked on, narrowed to that invoke's rows | every other activation the forward produces |
-| a worker's replacement value on a swap, and the value it was handed (written back so in-place edits land) | the tokenizer / pipeline: raw invoke inputs ship to the host and are assembled there |
+| a worker's replacement value on a swap, and the value it was handed (written back so in-place edits land) | invoke inputs: they ship raw and the host's tokenizer / pipeline assembles them (the runner's own tokenizer is a local copy, used only by the block) |
 | ad-hoc module calls (`model.lm_head(h)`) as a request/response | the module itself — the host runs its forward and returns the output |
 | `tracer.cache()` hits, filtered and moved off-device on the host | untargeted locations — a cache never ships what it wouldn't keep |
 | the block's stdout, one line at a time, surfaced as `LOG` responses | — |
 | the final `torch.save` blob of saved values (runner → host, uploaded as-is) | — |
 
-The runner holds **no model objects at all**. When the request is deserialized
-there, the model, its modules, and the tokenizer all resolve to `None`; only the
-interleaver is real, and it is wired to the socket. Everything the block does that
-looks like touching the model is a message.
+The runner holds **no weights**. It does hold a *meta* model — built from the model
+key when the runner starts — so when the request is deserialized there, the module
+tree, tokenizer and pipeline resolve to weightless local objects, and the
+interleaver resolves to one wired to the socket. Structural work (tokenizing,
+walking the tree) happens in the runner; anything that needs a real activation is
+still a message, because the meta modules have no values to give.
 
 ## What it implies
 

--- a/docs/developing/adding-a-model-actor.md
+++ b/docs/developing/adding-a-model-actor.md
@@ -72,7 +72,7 @@ by node, and GPU targeting happens inside the actor via `max_memory`.
 
 > **Gotcha:** an extra constructor parameter of your own has no path from the
 > controller. `SandboxModelDeployment.__init__` takes `pool_size: int = 2`
-> (`sandbox/model.py:173`) and nothing can set it — it is always 2 in production.
+> (`sandbox/model.py:176`) and nothing can set it — it is always 2 in production.
 > Read your own options from the environment (the actor's `runtime_env` carries the
 > provider config already) or add a field to `BaseModelDeploymentArgs`, which also
 > means teaching `DeploymentConfig` and the controller to populate it.

--- a/docs/developing/nnsight-integration.md
+++ b/docs/developing/nnsight-integration.md
@@ -109,11 +109,12 @@ tracer = RequestModel.deserialize(
 ```
 
 (`.../deployments/modeling/base.py:391-394` — the in-process path.) The sandbox
-runner calls the same function with its own unpickler
-(`.../sandbox/nns.py:346`):
+runner calls the same function with its own unpickler and its own map — built once
+per runner from a meta model, not from loaded weights (`.../sandbox/nns.py:369`):
 
 ```python
-tracer = RequestModel.deserialize(blob, compress=compress, unpickler=IPCCloudUnpickler)
+tracer = RequestModel.deserialize(blob, persistent_objects=PERSISTENT_OBJECTS,
+                                  compress=compress, unpickler=IPCCloudUnpickler)
 ```
 
 Inside, nnsight decompresses, unpickles (resolving persistent ids from the map),
@@ -229,17 +230,19 @@ extension points; prefer them over reaching further in.
 
 | Seam | Shape | NDIF's use |
 |---|---|---|
-| `deserialize(..., unpickler=)` | the unpickler class is a parameter; it is constructed as `unpickler(file, persistent_objects)` | the sandbox passes `IPCCloudUnpickler`, which resolves `"Interleaver"` to a socket-backed `IPCInterleaver` and **everything else to `None`** — the runner has no model |
-| `_remoteable_persistent_objects()` | model wrapper → `{persistent_id: live object}` | the in-process actor passes it straight to `deserialize`; subclasses extend it (tokenizer, pipeline) |
+| `deserialize(..., unpickler=)` | the unpickler class is a parameter; it is constructed as `unpickler(file, persistent_objects)` | the sandbox passes `IPCCloudUnpickler`, which resolves `"Interleaver"` to a socket-backed `IPCInterleaver`, other ids from its meta model's map, and **unknown ids to `None`** instead of raising |
+| `_remoteable_persistent_objects()` | model wrapper → `{persistent_id: live object}` | the in-process actor passes it straight to `deserialize`; the runner builds the same map from a meta model (`load_meta_model`, `.../sandbox/nns.py:341`); subclasses extend it (tokenizer, pipeline) |
 | `_remoteable_get_env()` / `_remoteable_set_env(env)` | client produces a dict, server applies it before the run | PEFT adapter swap; applied off the event loop inside `run`'s try block so a bad adapter id becomes a normal user-facing `ERROR` (`base.py:294`) |
 | `to_model_key()` / `from_model_key(key, **kwargs)` | `"import.path.ClassName:{...}"` | the deployment identity used everywhere — queue keys, actor names, `models.yaml` |
 | `Remotable.from_model_key(..., dispatch=False)` | build on the meta device | the controller's size estimate, before any weights exist |
 | `_saves()` / `inc()` / `dec()` | thread-local save set | collecting the values to return |
 | `cloudpickle.register_pickle_by_value` (via `nnsight.register`) | ship a local module's source | lets user code reference modules the server doesn't have installed |
 
-`IPCCloudUnpickler`'s "everything else is `None`" is the reason the runner
-process cannot touch the model even though the payload *mentions* it — the
-persistent-id indirection is what makes the sandbox's boundary expressible.
+The persistent-id indirection is what makes the sandbox's boundary expressible at
+all: the payload *mentions* the model everywhere, and what the runner ends up
+holding is entirely decided by the map it resolves against. Give it nothing and the
+model is `None`; give it a meta build and the runner gets structure but never
+weights.
 
 ## Developing against a local nnsight
 

--- a/docs/developing/sandbox-internals.md
+++ b/docs/developing/sandbox-internals.md
@@ -59,7 +59,7 @@ flowchart TB
     M["model + weights on GPU<br/>real Interleaver, forward hooks"]
     P["MediatorProxy per worker<br/>occurrence counter, pin, batch_group"]
   end
-  subgraph run["runner process (no model)"]
+  subgraph run["runner process (meta model, no weights)"]
     W["nns.run + IPCInterleaver.pump<br/>worker greenlets, one per invoke / edit"]
   end
   D --- M --- P
@@ -100,15 +100,15 @@ host owns the `.i{n}` occurrence tag.
 | `("THROW", id, requester, is_iter)` | h→r | worker `id` is still parked on `requester`, which the model never reached | `check_dangling`, `model.py:380` | none |
 | `("CACHE_HIT", cache_id, path, key, value)` | h→r | one filtered, transformed value for a `tracer.cache()` living in the runner | `ShippingCache._record`, `model.py:71` | none |
 | `("DONE", result)` | h→r | the forward pass returned `result` | `interleave`, `model.py:366` | none — ends `pump` |
-| `("INTERLEAVE", fn_name, parks, batch_groups, invokes, **kwargs)` | r→h | run wrapper method `fn_name` (`_call` / `generate` / `pipe`) on the model; one initial park per worker, each worker's `[start, size]` batch rows, the raw per-invoke inputs, and the trace-level forward kwargs | `IPCEnvoy.interleave`, `nns.py:220` | a stream of `RESUME`/`THROW`, then `DONE` |
-| `("PARK", id, park)` | r→h | worker `id`'s next park, or `None` if it finished | `pump`, `nns.py:145`; `writeback`, `:167` | `RESUME` (unless the run is ending) |
-| `("STOP",)` | r→h | a worker called `tracer.stop()` | `pump`, `nns.py:139` | none |
+| `("INTERLEAVE", fn_name, parks, batch_groups, invokes, **kwargs)` | r→h | run wrapper method `fn_name` (`_call` / `generate` / `pipe`) on the model; one initial park per worker, each worker's `[start, size]` batch rows, the raw per-invoke inputs, and the trace-level forward kwargs | `IPCEnvoy.interleave`, `nns.py:223` | a stream of `RESUME`/`THROW`, then `DONE` |
+| `("PARK", id, park)` | r→h | worker `id`'s next park, or `None` if it finished | `pump`, `nns.py:146`; `writeback`, `:170` | `RESUME` (unless the run is ending) |
+| `("STOP",)` | r→h | a worker called `tracer.stop()` | `pump`, `nns.py:140` | none |
 | `("PRINT", text)` | r→h | one complete line of the block's stdout | `Connection.print_event`, `runner.py:39` | none — echoed as a `LOG` response |
-| `("END", blob, deserialize_ms)` | r→h | `torch.save` of the block's saved values, plus the runner's deserialize time | `run`, `nns.py:378` | none |
-| `("EXCEPTION", text)` | r→h | the block raised; already-formatted traceback text | `run`, `nns.py:376` | none |
-| `("SOURCE", path, None)` | park | control park: source-instrument the module at `path` | `IPCSource.__init__`, `nns.py:273` | served by `install_source` (`model.py:281`) → operation names, or `None` if the forward can't be sourced |
-| `("CALL", path, None, hook, args, kwargs)` | park | control park: run the module's forward ad hoc (logit lens) | `IPCEnvoy.__call__`, `nns.py:234` | served by `run_module` (`model.py:293`) → the module's output |
-| `("CACHE", cache_id, None, config)` | park | control park: register a `tracer.cache()` filter | `ipc_cache`, `nns.py:321` | `settle_control` attaches a `ShippingCache` → `None` |
+| `("END", blob, deserialize_ms)` | r→h | `torch.save` of the block's saved values, plus the runner's deserialize time | `run`, `nns.py:401` | none |
+| `("EXCEPTION", text)` | r→h | the block raised; already-formatted traceback text | `run`, `nns.py:399` | none |
+| `("SOURCE", path, None)` | park | control park: source-instrument the module at `path` | `IPCSource.__init__`, `nns.py:284` | served by `install_source` (`model.py:281`) → operation names, or `None` if the forward can't be sourced |
+| `("CALL", path, None, hook, args, kwargs)` | park | control park: run the module's forward ad hoc (logit lens) | `IPCEnvoy.__call__`, `nns.py:237` | served by `run_module` (`model.py:293`) → the module's output |
+| `("CACHE", cache_id, None, config)` | park | control park: register a `tracer.cache()` filter | `ipc_cache`, `nns.py:332` | `settle_control` attaches a `ShippingCache` → `None` |
 
 The last three name nothing the forward produces: they ride inside a `PARK`, are
 drained by `settle_control` before `handle` sees them, and are answered in the next
@@ -120,15 +120,26 @@ drained by `settle_control` before `handle` sees them, and are answered in the n
 runner process plus its socket path, and `stop()` (`:65`) terminates it (SIGKILL
 after 5s) and unlinks the socket. `spawn` (`:79`) picks `/tmp/sbx-<12 hex>.sock`,
 copies the actor's environment, prepends the repo root to `PYTHONPATH` (so the
-runner can `import ndif.*`), launches the runner module, and polls until the
-socket accepts (30s), raising if the process dies first.
+runner can `import ndif.*`), launches the runner module with `runner_args`
+appended to its argv, and polls until the socket accepts (30s), raising if the
+process dies first.
 
 `Pool` (`:112`) keeps up to `size` runners pre-warmed on background threads
-(`refill`, `:134`) so acquiring one doesn't pay Python + nnsight import cost;
-`acquire` (`:155`) takes a warm one (spawning inline if the queue is empty) and
+(`refill`, `:135`) so acquiring one doesn't pay Python + nnsight import cost, nor
+the meta-model build the runner does before binding;
+`acquire` (`:158`) takes a warm one (spawning inline if the queue is empty) and
 tops the pool back up. **There is no release-back-to-pool** — the caller owns the
 process and must `stop()` it. `size` defaults to 2 via `SandboxModelDeployment`'s
-`pool_size` kwarg (`model.py:173`); no env var sets it.
+`pool_size` kwarg (`model.py:176`); no env var sets it. The pool also carries
+`runner_args` — `[self.model_key]` (`model.py:178`) — through to every `spawn`,
+which is how a runner knows which model to build its persistent-id map from.
+
+> **Gotcha:** a warm thread that fails to spawn is silent. `refill`'s `warm()` only
+> decrements the counter in its `finally`; the exception dies with the thread and
+> lands in the Ray worker's `.err` file, never the actor's log. The visible symptom
+> is `acquire` blocking for its full 30s timeout and then falling through to an
+> inline spawn.
+
 `SandboxModelDeployment` otherwise overrides only the seams of the
 `BaseModelDeployment.run` template (`base.py:244`) — `execute`, `execution_scope`,
 `interrupt` (`:201`), `cleanup` (`:196`), `format_error` (`:188`) — so the
@@ -136,29 +147,50 @@ timeout/cancel race, metrics, event logs, and upload stay shared.
 
 ## Runner side
 
-`Runner.serve` (`runner.py:75`) accepts connections one at a time forever (a
-failing exchange goes to stderr and doesn't kill the loop); `handle` (`:86`) reads
-`(blob, compress)`, redirects stdout to `Writer` (`:42`, one `PRINT` per complete
+`Runner.__init__` (`runner.py:69`) takes the socket path **and the model key** —
+`spawn` passes it as the second argv entry — and calls `nns.load_meta_model` before
+binding, so the process has an undispatched (weightless) model tree ready.
+`Runner.serve` (`:78`) accepts connections one at a time forever (a
+failing exchange goes to stderr and doesn't kill the loop); `handle` (`:89`) reads
+`(blob, compress)`, redirects stdout to `Writer` (`:45`, one `PRINT` per complete
 line, mirroring the in-process `LogStream`), and calls `nns.run`. `nns.run`
-(`nns.py:329`) deserializes with nnsight's own
+(`nns.py:352`) deserializes with nnsight's own
 `RequestModel.deserialize(..., unpickler=IPCCloudUnpickler)`, brackets
 `tracer.execute` in `inc()`/`dec()` so `nnsight.save()` records into this thread's
 save set, collects the marked frame locals by identity, and `torch.save`s them
 with the shared `cpu_pickle_module` (`deployments/modeling/util.py:269`) — so the
 host uploads the bytes as-is, no unpickle/repickle round trip. Tracebacks don't
 survive cloudpickle, so an exception is **formatted here** (preferring the
-worker's `__intervention_tb__`) and shipped as text. `IPCCloudUnpickler`
-(`nns.py:237`) is the only persistent-id resolution the runner does:
-`"Interleaver"` becomes an `IPCInterleaver` bound to this request's socket, and
-**everything else — the model, every module, the tokenizer — resolves to `None`**
-(`persistent_load`, `:248`).
+worker's `__intervention_tb__`) and shipped as text.
+
+`IPCCloudUnpickler` (`nns.py:240`) resolves the payload's persistent ids
+(`persistent_load`, `:254`) in three steps: `"Interleaver"` becomes an
+`IPCInterleaver` bound to this request's socket — checked first, so the meta
+model's own interleaver can't shadow it; anything in `PERSISTENT_OBJECTS`
+(`Module:<path>`, `Tokenizer`, `Pipeline`, …) resolves to the runner's **meta**
+object, which is what lets a block call `model.tokenizer(...)` without a round
+trip; and anything else resolves to `None` rather than raising
+`UnknownPersistentIdError` as the base class would.
+
+The map is built once per runner by `load_meta_model` (`:341`) from the model key,
+via `HuggingFaceModel.from_model_key(...)._remoteable_persistent_objects()` — the
+same map the in-process actor builds from its real model, which is why the keys
+line up. **Weights are still host-only**: a resolved module is the meta build's, so
+reading its activations crosses the socket exactly as before. What changed is that
+the runner can answer *structural* questions locally.
+
+> **Consequence:** the runner's tree and the host's must agree on module paths. They
+> do because both are derived from the same model key — but a model whose meta build
+> diverges from its loaded form (a `trust_remote_code` checkpoint, a PEFT-adapted
+> tree) will resolve ids to the wrong modules, and the `None` fallthrough means that
+> surfaces as an `AttributeError` in the block rather than an unpickling error.
 
 Importing `nns` installs process-wide patches, which is why `runner.py` imports it
-and the host never does: `Mediator.event` → `ipc_event` (`:74`, park untagged);
+and the host never does: `Mediator.event` → `ipc_event` (`:75`, park untagged);
 every callable on `IPCEnvoy` shadowing one on `Envoy` grafted onto `Envoy` itself
-(`:290`) — a whole-class patch, because the tracer's root is a model-wrapper
-subclass that *inherits* `interleave`; `Envoy.source` → `IPCSource` (`:296`); and
-`InterleavingTracer.cache` → `ipc_cache` (`:326`).
+(`:303`) — a whole-class patch, because the tracer's root is a model-wrapper
+subclass that *inherits* `interleave`; `Envoy.source` → `IPCSource` (`:307`); and
+`InterleavingTracer.cache` → `ipc_cache` (`:337`).
 
 ## The split interleaver
 
@@ -168,10 +200,10 @@ Each nnsight `Mediator` is cut in half at the model↔mediator seam:
 |---|---|---|
 | block execution / parking | worker greenlet; patched `Mediator.event` parks untagged with the pin | `MediatorProxy.adopt` tags `.i{n}` |
 | occurrence counting, pin relaxation | none (pin pushed back on every `RESUME`) | inherited `Mediator.handle` on the proxy |
-| forward hooks | `IPCInterleaver.instrument` is a no-op (`nns.py:101`) | the model's real `Interleaver` |
+| forward hooks | `IPCInterleaver.instrument` is a no-op (`nns.py:102`) | the model's real `Interleaver` |
 | batch scoping, input assembly | `batch_group` computed by the tracer, shipped | `Batcher` + `narrow`/`widen`, `_assemble` (`model.py:321`) |
 | `.source` / ad-hoc call / cache | `IPCSource`, `IPCEnvoy.__call__`, the real `Cache` | `install_source`, `run_module`, `ShippingCache` |
-| dangling workers | `IPCInterleaver.throw` (`nns.py:170`) | `check_dangling` sends `THROW` |
+| dangling workers | `IPCInterleaver.throw` (`nns.py:173`) | `check_dangling` sends `THROW` |
 
 `MediatorProxy` (`model.py:74`) **subclasses `Mediator` and reuses `handle`
 unchanged** — the matching, iteration, and relaxation logic is stock nnsight. It
@@ -180,10 +212,10 @@ overrides three things: `adopt` (`:100`) re-tags an incoming park, `switch`
 (`:143`) only records the interleaver (there is no local greenlet — the worker's
 first park arrived in `INTERLEAVE`). `alive` (`:151`) is "has a pending park".
 
-`IPCEnvoy.interleave` (`nns.py:197`) is the runner's entry into a model call: it
+`IPCEnvoy.interleave` (`nns.py:200`) is the runner's entry into a model call: it
 prepends the trace's edits, enters the interleaver (starting every worker so each
 parks on its first location), ships `INTERLEAVE`, then hands the socket to
-`IPCInterleaver.pump` (`:105`) until `DONE`. On the host,
+`IPCInterleaver.pump` (`:106`) until `DONE`. On the host,
 `SandboxModelDeployment.interleave` (`model.py:336`) builds one proxy per park,
 settles their control events, installs them as the model interleaver's mediators,
 assembles the inputs, runs `fn(...)` for real, serves the return value at
@@ -230,7 +262,7 @@ read then a swap three; a location no worker is parked on never crosses at all.
 nnsight splits occurrence handling between `Mediator.handle` (counts visits,
 relaxes a pin) and `Mediator.event` (tags a park from that count); here all of it
 lives on the host. The runner parks untagged with `worker.mediator().iteration` as
-`pin` (`ipc_event`, `nns.py:60`); `adopt` (`model.py:100`) sets
+`pin` (`ipc_event`, `nns.py:70`); `adopt` (`model.py:100`) sets
 `self.iteration = pin` and tags with `pin` when pinned, else with the proxy's own
 `iterations[location]` — the counter `handle` matches against; and every `RESUME`
 pushes the proxy's `iteration` back, which `pump` assigns to the runner-side
@@ -238,9 +270,10 @@ mediator (`nns.py:129`), so a pin relaxed on the host relaxes in the worker too.
 
 ### Batching
 
-The tracer computes each worker's `batch_group` in the runner, but the tokenizer
-and pipeline that turn text into model inputs live on the host — so the runner
-ships `batcher.invokes` raw (`IPCEnvoy.interleave`, `nns.py:219`) and the host
+The tracer computes each worker's `batch_group` in the runner, but assembly stays
+on the host — the runner's tokenizer and pipeline are meta-side copies the block
+may call directly, not the ones that feed the forward — so the runner
+ships `batcher.invokes` raw (`IPCEnvoy.interleave`, `nns.py:222`) and the host
 rebuilds a `Batcher`, `add`s each invoke, and calls `assemble(fn)` (`_assemble`,
 `model.py:321`); trace-level kwargs (`max_new_tokens`) win, and input tensors are
 device-placed (`_to_device`, `:272`). Each proxy carries its shipped `batch_group`
@@ -254,7 +287,7 @@ invoke's rows and widens its edit back into the batch.
 worker parks on a real model location — once per proxy before the forward starts,
 and again after every `switch`.
 
-`tracer.cache()` **is** supported over the socket: `ipc_cache` (`nns.py:299`)
+`tracer.cache()` **is** supported over the socket: `ipc_cache` (`nns.py:310`)
 builds the ordinary nnsight `Cache`/`CacheView` in the runner (so the client can
 deserialize it), registers it on `IPCInterleaver.caches`, and parks on `CACHE` with
 the filter config. The host attaches a `ShippingCache` (`model.py:46`) — a `Cache`
@@ -267,8 +300,8 @@ worker's rows; `pump` records each hit into the runner's cache (`nns.py:149`).
 | Path | Trigger | Mechanism |
 |---|---|---|
 | Normal | block finishes | forward returns → `DONE` → `pump` returns → block ends → `END` with the saved-values blob → host uploads it |
-| `tracer.stop()` | `EarlyStopException` in a worker | `pump` sends `STOP` and re-raises (`nns.py:139`); the proxy's `switch` raises `EarlyStopException` on the host, unwinding the forward, which `Interleaver.__exit__` swallows; `IPCEnvoy.interleave` swallows it in the runner too |
-| Dangling worker | worker still parked after the forward | `check_dangling` (`model.py:368`) sends `THROW`; `IPCInterleaver.throw` (`nns.py:170`) raises `OutOfOrderError` into the worker — or, for `iteration != 0` (an open-ended `tracer.iter` that outran the model), catches it and warns |
+| `tracer.stop()` | `EarlyStopException` in a worker | `pump` sends `STOP` and re-raises (`nns.py:140`); the proxy's `switch` raises `EarlyStopException` on the host, unwinding the forward, which `Interleaver.__exit__` swallows; `IPCEnvoy.interleave` swallows it in the runner too |
+| Dangling worker | worker still parked after the forward | `check_dangling` (`model.py:368`) sends `THROW`; `IPCInterleaver.throw` (`nns.py:173`) raises `OutOfOrderError` into the worker — or, for `iteration != 0` (an open-ended `tracer.iter` that outran the model), catches it and warns |
 | Block error | any exception in the runner | formatted in `nns.run`, sent as `EXCEPTION`; `next_event` (`model.py:214`) raises `RunnerError`; `format_error` returns it verbatim, non-fatal |
 | Timeout / cancel | `run`'s race (`base.py:298`) | `interrupt` (`model.py:201`) stops the runner; the host thread's `recv` fails with `ConnectionError` |
 | Always | after every request | `cleanup` (`:196`) → `discard_sandbox` stops the request's runner |

--- a/docs/developing/testing.md
+++ b/docs/developing/testing.md
@@ -66,7 +66,7 @@ there is no environment variable for it.
 
 ## What the suite covers
 
-50 tests across 18 classes in `tests/test_nnsight_remote.py`, each one opening a
+51 tests across 18 classes in `tests/test_nnsight_remote.py`, each one opening a
 real `with model.trace(..., remote=True):`.
 
 | Class | What it proves about the server |
@@ -83,7 +83,7 @@ real `with model.trace(..., remote=True):`.
 | `TestRemoteGradients` | Backward works once an activation is opted in — the server loads weights with `requires_grad_(False)`. |
 | `TestRemoteCache` | `tracer.cache()` round-trips and captures every reached module. |
 | `TestRemotePeft` | A per-request PEFT adapter id rides on the request env and is applied before the run. |
-| `TestNdif` | `nnsight.status()`, `is_model_running`, `get_remote_env`, `compare` against the live `/status` and `/env`. |
+| `TestNdif` | `nnsight.status()`, `is_model_running`, `get_remote_env`, `compare` against the live `/status` and `/env`; also `test_persistent_objects`, which tokenizes inside the block and asserts it matches a local tokenization — on the sandbox path that only passes because the runner resolves `Tokenizer` from its own meta model. |
 | `TestRemoteLocalCode` | Non-installed local modules/classes ship to the server by value automatically. |
 | `TestRemoteNonBlocking` | `blocking=False` submit, then poll `GET /response/{id}` — needs object-store response persistence. |
 | `TestRemoteEdit` | `model.edit()` edits ride to the server and apply. |
@@ -161,7 +161,7 @@ divergence is a sandbox bug (or a new xfail), and
 `src/ndif/services/ray/sandbox/ARCHITECTURE.md`'s "Current simplifications"
 section is where the deliberate ones are listed. Read that list against the code
 before believing it: `tracer.cache()` is listed as unsupported but is in fact
-served over IPC now (`sandbox/model.py:133`, `sandbox/nns.py:321`).
+served over IPC now (`sandbox/model.py:133`, `sandbox/nns.py:332`).
 
 **The faithful way**, if you want the real trust plumbing rather than a client-set
 flag: uncomment `NDIF_POSTGRES_URL` in `docker/docker-compose.yml:156`, insert a

--- a/docs/errors/server-exceptions.md
+++ b/docs/errors/server-exceptions.md
@@ -36,7 +36,7 @@ Three facts organise everything below:
 |---|---|---|---|---|
 | `RunnerError` | defined `sandbox/model.py:40`, raised `sandbox/model.py:229` | `ERROR` with the block's own traceback | The user's block raised inside the runner process | **user** |
 | Any block exception (trusted path) | propagates out of `BaseModelDeployment.execute`, `base.py:379`, caught at `base.py:343` | `ERROR` with the block's own traceback | The user's block raised in the actor process | **user** |
-| `OutOfOrderError` | thrown into a worker by `IPCInterleaver.throw`, `sandbox/nns.py:170` | `ERROR`: `'<location>' was requested but the model already ran past it` | A worker was still parked on a location the forward pass never reached | **user** |
+| `OutOfOrderError` | thrown into a worker by `IPCInterleaver.throw`, `sandbox/nns.py:173` | `ERROR`: `'<location>' was requested but the model already ran past it` | A worker was still parked on a location the forward pass never reached | **user** |
 | `EarlyStopException` | `sandbox/model.py:140`, `:164`; nnsight's `tracer.stop()` | nothing — the job completes normally | Intentional early stop | **neither** |
 | *(no exception)* — timeout | the race in `base.py:298` expires | `ERROR`: `Your job exceeded the execution timeout of {n}s.` | Block ran past `execution_timeout` | **user** (usually) |
 | *(no exception)* — kill switch | `base.py:316` | `ERROR`: `Your job was cancelled or preempted by the server.` | `ndif kill`, or an operator cancel | **operator** |
@@ -47,7 +47,7 @@ Three facts organise everything below:
 | `ConnectionError` | `sandbox/protocol.py:79` | `ERROR` (host-side traceback) | The runner died or was stopped mid-exchange | **server** (or a deliberate interrupt) |
 | `RuntimeError: runner process exited before its socket was ready` | `sandbox/host.py:106` | `ERROR` (host-side traceback) | The runner subprocess crashed at import | **server** |
 | `TimeoutError: timed out waiting for the runner socket` | `sandbox/host.py:109` | `ERROR` (host-side traceback) | Runner took >30s to bind its socket | **server** |
-| `ModuleNotFoundError` / unpickling errors | inside `RequestModel.deserialize`, called from `base.py:379` or `sandbox/nns.py:346` | `ERROR` with the deserialize traceback | The payload references a module the server doesn't have | **user** |
+| `ModuleNotFoundError` / unpickling errors | inside `RequestModel.deserialize`, called from `base.py:379` or `sandbox/nns.py:369` | `ERROR` with the deserialize traceback | The payload references a module the server doesn't have | **user** |
 | `torch.cuda.OutOfMemoryError` (at run) | inside the block, `base.py:379` | `ERROR` with a CUDA OOM traceback | The request's activations exceeded the replica's budget | **user** |
 | `torch.cuda.OutOfMemoryError` / `RuntimeError` (at load) | `load_from_disk`, `base.py:144` | `ERROR`: `Error starting model...` | The controller's size estimate was wrong, or the GPU wasn't actually free | **server** |
 | `RuntimeError` from `verify_device_placement` | `modeling/util.py:166` | `ERROR`: `Error starting model...` | A weight landed on `meta`, `cpu`, or an unassigned GPU | **server** |
@@ -71,7 +71,7 @@ class RunnerError(Exception):
 The runner catches everything out of the block, formats the traceback **in its
 own process** — preferring the worker's `__intervention_tb__` when the failure
 came from intervention code, else nnsight's `clean_traceback` — and sends
-`("EXCEPTION", text)` (`sandbox/nns.py:363`-`378`). On the host, `next_event`
+`("EXCEPTION", text)` (`sandbox/nns.py:386`-`401`). On the host, `next_event`
 turns that into `raise RunnerError(text)` (`model.py:229`), and
 `SandboxModelDeployment.format_error` (`model.py:188`) returns the string
 verbatim with `fatal=False`:
@@ -92,7 +92,7 @@ plumbing and the actor's own frames before formatting.
 After the forward pass returns, `check_dangling` (`model.py:368`) looks for
 proxies still holding a park — a worker waiting on a location the model never
 reached — and sends `("THROW", id, requester, iteration != 0)` (`model.py:380`).
-The runner's `IPCInterleaver.throw` (`nns.py:170`) constructs the error and
+The runner's `IPCInterleaver.throw` (`nns.py:173`) constructs the error and
 throws it into the greenlet so the traceback points at the line that was waiting:
 
 ```python
@@ -118,10 +118,10 @@ modules in forward-pass order, or bound the iteration.
 ### EarlyStopException — not an error
 
 `tracer.stop()` raises `EarlyStopException` in a worker. Over the socket the
-runner's `pump` sends `("STOP",)` and re-raises (`nns.py:139`); on the host both
+runner's `pump` sends `("STOP",)` and re-raises (`nns.py:140`); on the host both
 `MediatorProxy.switch` (`model.py:164`) and `settle_control` (`model.py:140`)
 raise it to unwind the forward pass, which the model's `Interleaver.__exit__`
-swallows, and `IPCEnvoy.interleave` swallows it in the runner too (`nns.py:224`).
+swallows, and `IPCEnvoy.interleave` swallows it in the runner too (`nns.py:227`).
 The job proceeds to upload its saves and completes. Seeing this in a stack trace
 is normal.
 

--- a/docs/runbooks/trace-a-users-failed-job.md
+++ b/docs/runbooks/trace-a-users-failed-job.md
@@ -110,7 +110,7 @@ as an `EXCEPTION` event:
         terminal = ("EXCEPTION", message)
 ```
 
-— `src/ndif/services/ray/sandbox/nns.py:372-376`. The host turns that event into
+— `src/ndif/services/ray/sandbox/nns.py:395-399`. The host turns that event into
 a `RunnerError` carrying the text (`sandbox/model.py:228-229`), and
 `SandboxModelDeployment.format_error` returns it verbatim and marks it
 **non-fatal — it's user code** (`sandbox/model.py:188-194`). `run()` then sends it

--- a/src/ndif/services/ray/sandbox/ARCHITECTURE.md
+++ b/src/ndif/services/ray/sandbox/ARCHITECTURE.md
@@ -36,7 +36,7 @@ across a process boundary.
 |------|------|
 | [`model.py`](model.py) | `SandboxModelDeployment` — the actor. Loads the model on the host (base class), owns a pool of runners, drives one per request, and holds the **host side** of the interleaver (`MediatorProxy`). |
 | [`host.py`](host.py) | Host-side plumbing: `spawn` a runner, `Pool` that pre-warms runners and hands out a **fresh one per request** (stopped when done), `Sandbox` handle, and the transport `Connection`. |
-| [`runner.py`](runner.py) | The runner process (`python -m sandbox.runner <socket>`). Accepts a connection, receives the payload, and calls `nns.run`. Importing `nns` here installs the IPC patches — **in the runner, never on the host**. |
+| [`runner.py`](runner.py) | The runner process (`python -m sandbox.runner <socket> <model_key>`). Accepts a connection, receives the payload, and calls `nns.run`. Importing `nns` here installs the IPC patches — **in the runner, never on the host**. |
 | [`nns.py`](nns.py) | The nnsight glue that runs **inside the runner**: deserialize the tracer, execute the block, and host the **worker side** of the interleaver (`IPCInterleaver`, patched `Mediator.event`, `IPCEnvoy`). |
 | [`protocol.py`](protocol.py) | The wire contract: framing, a type-tagged codec, and the authoritative **message catalog**. |
 
@@ -50,7 +50,7 @@ across a process boundary.
                         │  Unix socket (protocol.py)
                         │  RESUME / PARK / THROW / DONE / INTERLEAVE / …
         ┌───────────────┴───────────────────────▼─────────────────────┐
-        │  runner process (no model)                                   │
+        │  runner process (meta model, no weights)                     │
         │    • nns.run: deserialize + execute the traced block         │
         │    • IPCInterleaver + worker greenlets  (worker side)        │
         └──────────────────────────────────────────────────────────────┘
@@ -82,8 +82,10 @@ across a process boundary.
    `nns.run`, which:
    - Deserializes the tracer with `IPCCloudUnpickler`. Persistent ids resolve
      specially here: the **interleaver** → an `IPCInterleaver` bound to this socket;
-     the **model and its modules** → `None` (they live on the host and are never
-     touched in the runner).
+     the **model, its modules and its tokenizer** → the runner's own *meta* build
+     (structure, no weights), registered by `load_meta_model` at startup; anything
+     unknown → `None`. The weights live on the host and are never touched here, so
+     every activation still crosses the socket.
    - Runs `tracer.execute(...)`. The block runs as a set of greenlet **workers**.
      Whenever the block calls the model, it hits `IPCEnvoy.interleave`.
 
@@ -208,8 +210,8 @@ executed in the runner process; the host never imports `nns`. This is also why t
 handoff is a plain `(blob, compress)` message rather than a pickled callable — the
 runner already knows to run `nns.run`.
 
-The runner runs as `python -m ndif.services.ray.sandbox.runner` (with the repo
-root on `PYTHONPATH`), i.e. as a normal `ndif` submodule, so it can reuse ndif
+The runner runs as `python -m ndif.services.ray.sandbox.runner <socket> <model_key>`
+(with the repo root on `PYTHONPATH`), i.e. as a normal `ndif` submodule, so it can reuse ndif
 helpers rather than duplicate them: `nns.run` deserializes via nnsight's own
 `RequestModel.deserialize(..., unpickler=IPCCloudUnpickler)` (an unpickler hook
 added to nnsight), and imports `cpu_pickle_module` from `deployments/modeling/util`.

--- a/src/ndif/services/ray/sandbox/host.py
+++ b/src/ndif/services/ray/sandbox/host.py
@@ -76,7 +76,7 @@ class Sandbox:
             pass
 
 
-def spawn(python: str = sys.executable, quiet: bool = True, timeout: float = 30.0) -> Sandbox:
+def spawn(python: str = sys.executable, runner_args=[], quiet: bool = True, timeout: float = 30.0) -> Sandbox:
     """Launch a runner process and wait until its socket is accepting."""
     path = f"/tmp/sbx-{uuid.uuid4().hex[:12]}.sock"
     env = dict(os.environ)
@@ -85,7 +85,7 @@ def spawn(python: str = sys.executable, quiet: bool = True, timeout: float = 30.
     )
     output = subprocess.DEVNULL if quiet else None
     process = subprocess.Popen(
-        [python, "-m", "ndif.services.ray.sandbox.runner", path],
+        [python, "-m", "ndif.services.ray.sandbox.runner", path] + runner_args,
         env=env,
         stdin=subprocess.DEVNULL,
         stdout=output,
@@ -120,8 +120,9 @@ class Pool:
     release-back-to-pool.
     """
 
-    def __init__(self, size: int = 2, python: str = sys.executable, quiet: bool = True):
+    def __init__(self, size: int = 2, runner_args=[], python: str = sys.executable, quiet: bool = True):
         self.size = size
+        self.runner_args = runner_args
         self.python = python
         self.quiet = quiet
         self.ready: "queue.Queue" = queue.Queue()
@@ -141,7 +142,9 @@ class Pool:
 
         def warm():
             try:
-                sandbox = spawn(python=self.python, quiet=self.quiet)
+                sandbox = spawn(
+                    python=self.python, runner_args=self.runner_args, quiet=self.quiet
+                )
             finally:
                 with self.lock:
                     self.spawning -= 1
@@ -158,7 +161,9 @@ class Pool:
         try:
             sandbox = self.ready.get(timeout=timeout)
         except queue.Empty:
-            sandbox = spawn(python=self.python, quiet=self.quiet)
+            sandbox = spawn(
+                python=self.python, runner_args=self.runner_args, quiet=self.quiet
+            )
         self.refill()
         return sandbox
 

--- a/src/ndif/services/ray/sandbox/model.py
+++ b/src/ndif/services/ray/sandbox/model.py
@@ -175,7 +175,7 @@ class SandboxModelDeployment(BaseModelDeployment):
 
     def __init__(self, *args: Any, pool_size: int = 2, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.pool = Pool(size=pool_size)
+        self.pool = Pool(size=pool_size, runner_args=[self.model_key], quiet=False)
         # The runner currently executing (fresh per request), tracked so run() can
         # stop it to interrupt a timed-out or cancelled request.
         self.execution_sandbox = None

--- a/src/ndif/services/ray/sandbox/nns.py
+++ b/src/ndif/services/ray/sandbox/nns.py
@@ -49,6 +49,7 @@ from nnsight.intervention.source import SourceEnvoy
 from nnsight.intervention.tracer import InterleavingTracer
 from nnsight.schema.request import RequestModel
 from nnsight.tracing.tracer import _saves, dec, inc
+from nnsight.modeling.huggingface import HuggingFaceModel
 
 from ..deployments.modeling.util import cpu_pickle_module
 
@@ -245,7 +246,7 @@ class IPCCloudUnpickler(CustomCloudUnpickler):
     """
 
     def __init__(self, file, persistent_objects=None):
-        super().__init__(file, persistent_objects=None)
+        super().__init__(file, persistent_objects=persistent_objects)
 
     def persistent_load(self, pid):
         # One interleaver is shared across the envoy tree; bind it to this
@@ -253,6 +254,9 @@ class IPCCloudUnpickler(CustomCloudUnpickler):
         # model, its modules) is never touched in this process.
         if pid == "Interleaver":
             return IPCInterleaver(connection)
+        elif pid in self.persistent_objects:
+            return self.persistent_objects[pid]
+
         return None
 
 
@@ -327,6 +331,10 @@ def ipc_cache(self, *args, **kwargs):
 _original_cache = InterleavingTracer.cache
 InterleavingTracer.cache = ipc_cache
 
+PERSISTENT_OBJECTS = {}
+
+def load_meta_model(model_key):
+    PERSISTENT_OBJECTS.update(HuggingFaceModel.from_model_key(model_key)._remoteable_persistent_objects())
 
 def run(conn, blob: bytes, compress: bool = False) -> None:
     """Deserialize the request in this process and execute it; interleave over IPC.
@@ -345,7 +353,7 @@ def run(conn, blob: bytes, compress: bool = False) -> None:
         # Same rebuild as a normal server (code recompiled, scope restored), but
         # with our unpickler so persistent ids resolve to the IPC interleaver / None.
         deserialize_started = time.time()
-        tracer = RequestModel.deserialize(blob, compress=compress, unpickler=IPCCloudUnpickler)
+        tracer = RequestModel.deserialize(blob, persistent_objects=PERSISTENT_OBJECTS, compress=compress, unpickler=IPCCloudUnpickler)
         deserialize_ms = round((time.time() - deserialize_started) * 1000, 2)
         # Bracket execution in a trace scope so nnsight.save() records into this
         # thread's save set, then collect the marked values (by identity) by name.

--- a/src/ndif/services/ray/sandbox/nns.py
+++ b/src/ndif/services/ray/sandbox/nns.py
@@ -238,11 +238,14 @@ class IPCEnvoy(Envoy):
 
 
 class IPCCloudUnpickler(CustomCloudUnpickler):
-    """nnsight unpickler that resolves the interleaver to an IPC one, model to None.
+    """nnsight unpickler that resolves the interleaver to an IPC one.
 
     Passed to ``RequestModel.deserialize(..., unpickler=IPCCloudUnpickler)``, which
-    instantiates it as ``IPCCloudUnpickler(file, persistent_objects)``; the sandbox
-    has no persistent objects, so they're ignored.
+    instantiates it as ``IPCCloudUnpickler(file, persistent_objects)`` — here the
+    map ``load_meta_model`` built from this runner's meta model, so ``Module:<path>``,
+    ``Tokenizer`` and ``Pipeline`` ids resolve to real (weightless) objects in this
+    process. Unlike the base class an unknown id is not an error: it resolves to
+    ``None``, since the payload can mention objects only the host has.
     """
 
     def __init__(self, file, persistent_objects=None):
@@ -250,8 +253,10 @@ class IPCCloudUnpickler(CustomCloudUnpickler):
 
     def persistent_load(self, pid):
         # One interleaver is shared across the envoy tree; bind it to this
-        # request's socket. Everything else a normal server would resolve (the
-        # model, its modules) is never touched in this process.
+        # request's socket. Checked before the map so the meta model's own
+        # interleaver (also keyed "Interleaver") can't shadow the IPC one. The model
+        # weights themselves are never in this process — a resolved module is the
+        # meta build's, and reads of its activations still cross the socket.
         if pid == "Interleaver":
             return IPCInterleaver(connection)
         elif pid in self.persistent_objects:
@@ -334,6 +339,14 @@ InterleavingTracer.cache = ipc_cache
 PERSISTENT_OBJECTS = {}
 
 def load_meta_model(model_key):
+    """Build this runner's meta model and register its persistent-id map.
+
+    Called once at runner start (``Runner.__init__``, before the socket binds), so
+    every request this process serves resolves ``Module:<path>`` / ``Tokenizer`` /
+    ``Pipeline`` against a tree with the same paths as the host's real model. The
+    build is undispatched — structure only, no weights — and its cost is paid per
+    runner, i.e. inside ``spawn``'s readiness window.
+    """
     PERSISTENT_OBJECTS.update(HuggingFaceModel.from_model_key(model_key)._remoteable_persistent_objects())
 
 def run(conn, blob: bytes, compress: bool = False) -> None:

--- a/src/ndif/services/ray/sandbox/runner.py
+++ b/src/ndif/services/ray/sandbox/runner.py
@@ -66,10 +66,11 @@ class Writer:
 class Runner:
     """Serves user code over a Unix socket."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, model_key: str):
         self.path = path
         if os.path.exists(path):
             os.unlink(path)
+        nns.load_meta_model(model_key)
         self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.socket.bind(path)
         self.socket.listen()
@@ -96,4 +97,4 @@ class Runner:
 
 
 if __name__ == "__main__":
-    Runner(sys.argv[1]).serve()
+    Runner(*sys.argv[1:]).serve()

--- a/tests/test_nnsight_remote.py
+++ b/tests/test_nnsight_remote.py
@@ -363,6 +363,15 @@ class TestNdif:
         assert isinstance(result.mismatches, dict)
         assert "Python Version:" in str(result)  # printable
 
+    
+    def test_persistent_objects(self, model):
+        tokens = model.tokenizer("Hello World!", return_tensors="pt")["input_ids"]
+
+        with model.trace("Hi", remote=True):
+            tokens_remote = model.tokenizer("Hello World!", return_tensors="pt")["input_ids"].save()
+
+        assert torch.equal(tokens, tokens_remote)
+
 
 
 def _inline_negate(x):


### PR DESCRIPTION
## Summary
The sandbox runner deserialized against nothing: IPCCloudUnpickler resolved "Interleaver" to a socket-backed IPCInterleaver and every other persistent id to None. Activation access was fine (reads/swaps cross the socket regardless), but anything structural wasn't — a block calling model.tokenizer(...) got None and an AttributeError on the untrusted path while working on the trusted one, breaking the invariant that both paths behave identically.

Each runner now builds its own meta model from the model key at startup and resolves Module:<path> / Tokenizer / Pipeline against it. The build is undispatched, so weights stay host-only and every activation still crosses the socket.

## Changes
- runner.py — Runner(path, model_key) calls nns.load_meta_model before binding, so the socket only accepts once the tree is ready.
- nns.py — load_meta_model populates PERSISTENT_OBJECTS from _remoteable_persistent_objects(); run passes it to deserialize. persistent_load still matches "Interleaver" first (so the meta model's own interleaver can't shadow the IPC one), then the map, then None — unknown ids don't raise.
- host.py / model.py — spawn/Pool carry runner_args onto the runner's argv; the deployment passes [self.model_key].
- Tests — test_persistent_objects tokenizes inside a remote block; passes trivially when trusted, only passes sandboxed because of this change.
- Docs — several pages claimed the model, modules and tokenizer "all resolve to None"; updated, along with citation drift in five others.