### PR TITLE
tests: add offline API pytest foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,11 +413,19 @@ ndif doctor                     # verify
 ndif start                      # run the stack
 ```
 
-Most tests need a running stack:
+Install the development dependencies and run the API unit tests without starting
+any NDIF services:
 
 ```bash
-cd tests
-pytest --run-remote             # against localhost:5001
+uv sync --group dev
+uv run pytest src/ndif/services/api/tests/unit
+```
+
+Most tests in the repository-level suite need a running stack. From the
+repository root:
+
+```bash
+uv run pytest tests --run-remote  # against localhost:5001
 ```
 
 ### Docker dev loop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,6 @@ dev = [
     "pytest>=8.4.0",
     "pytest-asyncio>=1.3.0",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/ndif/services/api/tests/unit/conftest.py
+++ b/src/ndif/services/api/tests/unit/conftest.py
@@ -1,5 +1,5 @@
 import os
-os.environ["DEV_MODE"] = "true"
+os.environ["NDIF_DEV_MODE"] = "true"
 os.environ.setdefault("NDIF_BROKER_URL", "redis://localhost:6379")
 
 from unittest.mock import AsyncMock, Mock, patch
@@ -11,3 +11,4 @@ mock_socket_manager = Mock()
 patch("socketio.AsyncRedisManager", return_value=mock_redis_manager).start()
 patch("redis.asyncio.Redis.from_url", return_value=mock_redis_client).start()
 patch("fastapi_socketio.SocketManager", return_value=mock_socket_manager).start()
+patch("ndif.common.providers.objectstore.ObjectStoreProvider.connect").start()

--- a/src/ndif/services/api/tests/unit/test_config.py
+++ b/src/ndif/services/api/tests/unit/test_config.py
@@ -1,0 +1,14 @@
+"""Unit tests for API configuration parsing helpers."""
+
+import pytest
+
+from ndif.services.api.config import AppConfig
+
+
+def test_parse_positive_int() -> None:
+    assert AppConfig._parse_positive_int("12", "EXAMPLE_LIMIT") == 12
+
+
+def test_parse_positive_int_rejects_zero() -> None:
+    with pytest.raises(ValueError, match="EXAMPLE_LIMIT: 0 must be a positive integer"):
+        AppConfig._parse_positive_int("0", "EXAMPLE_LIMIT")

--- a/src/ndif/services/api/tests/unit/test_smoke.py
+++ b/src/ndif/services/api/tests/unit/test_smoke.py
@@ -1,0 +1,5 @@
+"""Basic proof that the API unit-test runner discovers and executes tests."""
+
+
+def test_pytest_runner() -> None:
+    assert "hello world".upper() == "HELLO WORLD"


### PR DESCRIPTION
## Summary

- add the required hello-world smoke test
- add positive and invalid-value coverage for API configuration parsing
- add pytest src-layout configuration and document the offline unit-test command
- correct the unit fixture dev-mode variable and prevent object-store startup so the suite stays offline

Existing application and dependency test modules are unchanged.

## Validation

- API unit suite: 8 passed
- `ruff check src/ndif/services/api/tests/unit/test_config.py src/ndif/services/api/tests/unit/test_smoke.py`
- `ruff format --check src/ndif/services/api/tests/unit/test_config.py src/ndif/services/api/tests/unit/test_smoke.py`
- `git diff --check`

Closes #172